### PR TITLE
Remove latest version tag

### DIFF
--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -87,10 +87,10 @@ function parseFlags() {
     while (($#)); do
         case "$1" in
             --src)
-                src_docker_image="$2:latest"
+                src_docker_image="$2"
                 shift 2 ;;
             --dst)
-                dst_docker_image="$2:latest"
+                dst_docker_image="$2"
                 shift 2 ;;
             --src.*)
                 IFS='.' read -ra strarr <<< $1


### PR DESCRIPTION
## Description

Remove latest version tag. This allows users to specif any version. IF the version is not specified, docker automatically will pull the latest anyways.


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
