### PR TITLE
Source catalog input & retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ CLI for running Airbyte sources & destinations locally without Airbyte server
    --dst.faros_api_key '<faros_api_key>' \
    --dst.graph 'default' \
    --state state.json \
+   --catalog servicenow.json \
    --check-connection
 ```

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -104,8 +104,9 @@ function writeSrcCatalog() {
                 exit 1
             fi
             
+            echo "$http_response_body" | jq '.streams'
             src_catalog=$(echo "$http_response_body" | \
-                          jq '.streams = [.streams[] |= {stream: {name: .stream.name}, sync_mode: .config.syncMode, destination_sync_mode: .config.destinationSyncMode}]')
+                          jq '.streams[] |= {stream: {name: .stream.name}, sync_mode: .config.syncMode, destination_sync_mode: .config.destinationSyncMode}')
             echo $src_catalog | jq > "$tempdir/$src_catalog_filename"
         fi
     else

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -104,10 +104,9 @@ function writeSrcCatalog() {
                 exit 1
             fi
             
-            echo "$http_response_body" | jq '.streams'
             src_catalog=$(echo "$http_response_body" | \
                           jq '.streams[] |= {stream: {name: .stream.name}, sync_mode: .config.syncMode, destination_sync_mode: .config.destinationSyncMode}')
-            echo $src_catalog | jq > "$tempdir/$src_catalog_filename"
+            echo $src_catalog > "$tempdir/$src_catalog_filename"
         fi
     else
         echo "Error: $src_docker_image is currently not supported"

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -92,7 +92,7 @@ function writeSrcCatalog() {
         else
             echo "Retrieving catalog from faros-ai/airbyte-connectors-configs"
             http_response=$(curl -s --write-out "HTTPSTATUS:%{http_code}" \
-                          "https://raw.githubusercontent.com/faros-ai/airbyte-connectors-configs/main/catalogs/${source_type}.json?token=GHSAT0AAAAAABVTX6NBUUZCEKCUY4YFJHJEYVQ3MWQ")
+                          "https://raw.githubusercontent.com/faros-ai/airbyte-connectors-configs/main/catalogs/${source_type}.json")
 
             http_response_status=$(echo "$http_response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
             http_response_body=$(echo "$http_response" | sed -e 's/HTTPSTATUS\:.*//g')

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -92,7 +92,7 @@ function writeSrcCatalog() {
         else
             echo "Retrieving catalog from faros-ai/airbyte-connectors-configs"
             http_response=$(curl -s --write-out "HTTPSTATUS:%{http_code}" \
-                          "https://raw.githubusercontent.com/faros-ai/airbyte-connectors-configs/main/catalogs/${source_type}.json")
+                          "https://raw.githubusercontent.com/faros-ai/airbyte-connectors-configs/main/catalogs/${source_type}.json?token=GHSAT0AAAAAABVTX6NBUUZCEKCUY4YFJHJEYVQ3MWQ")
 
             http_response_status=$(echo "$http_response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
             http_response_body=$(echo "$http_response" | sed -e 's/HTTPSTATUS\:.*//g')
@@ -104,7 +104,9 @@ function writeSrcCatalog() {
                 exit 1
             fi
             
-            echo $http_response_body | jq > "$tempdir/$src_catalog_filename"
+            src_catalog=$(echo "$http_response_body" | \
+                          jq '.streams = [.streams[] |= {stream: {name: .stream.name}, sync_mode: .config.syncMode, destination_sync_mode: .config.destinationSyncMode}]')
+            echo $src_catalog | jq > "$tempdir/$src_catalog_filename"
         fi
     else
         echo "Error: $src_docker_image is currently not supported"

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -90,7 +90,7 @@ function writeSrcCatalog() {
             echo "Using catalog: $src_catalog_filepath"
             cat "$src_catalog_filepath" | jq > "$tempdir/$src_catalog_filename"
         else
-            echo "Retrieve catalog from faros-ai/airbyte-connectors-configs..."
+            echo "Retrieving catalog from faros-ai/airbyte-connectors-configs"
             http_response=$(curl -s --write-out "HTTPSTATUS:%{http_code}" \
                           "https://raw.githubusercontent.com/faros-ai/airbyte-connectors-configs/main/catalogs/${source_type}.json")
 

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -92,7 +92,7 @@ function writeSrcCatalog() {
         else
             echo "Retrieving catalog from faros-ai/airbyte-connectors-configs"
             http_response=$(curl -s --write-out "HTTPSTATUS:%{http_code}" \
-                          "https://raw.githubusercontent.com/faros-ai/airbyte-connectors-configs/main/catalogs/${source_type}.json")
+                            "https://raw.githubusercontent.com/faros-ai/airbyte-connectors-configs/main/catalogs/${source_type}.json")
 
             http_response_status=$(echo "$http_response" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
             http_response_body=$(echo "$http_response" | sed -e 's/HTTPSTATUS\:.*//g')


### PR DESCRIPTION
## Description

This PR enhances source catalog interactions. I have added support for pointing to a catalog file as well as retrieving the catalog json from our airbyte-connectors-configs repository (which I propose we make public - if we dont want to, i can remove that functionality)

## Type of change
- [ ] Bug fix
- [X] New feature
- [X] Breaking change - servicenow & pagerduty sources will need to have their catalogs either input or retrieved.
