### PR TITLE
Use tee to process source output

### DIFF
--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -100,8 +100,13 @@ function writeSrcCatalog() {
     }' > $tempdir/$src_catalog_filename
     IFS='-' read -ra src_docker_image_parts <<< $src_docker_image
     if [[ $dst_docker_image == farosai/airbyte-faros-destination* ]] && [[ ${src_docker_image_parts[0]} == farosai/airbyte ]]; then
-        src_type=${src_docker_image_parts[1]}
-        stream_prefix="my${src_type}src__${src_type}__"
+        # Remove first and last elements
+        src_docker_image_parts=("${src_docker_image_parts[@]:1}")
+        src_docker_image_parts=("${src_docker_image_parts[@]::${#src_docker_image_parts[@]}-1}");
+
+        src_origin=$(IFS= ; echo "${src_docker_image_parts[*]}")
+        src_type=$(IFS=_ ; echo "${src_docker_image_parts[*]}")
+        stream_prefix="my${src_origin}src__${src_type}__"
     else
         echo "Error: $src_docker_image is currently not supported"
         exit 1

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -154,7 +154,6 @@ function loadState() {
 }
 
 function sync() {
-    source_output_file="$tempdir/source_output.txt"
     new_source_state_file="$tempdir/new_state.json"
     readSrc | \
         tee >(jq -c -R $jq_cmd "fromjson? | select(.type == \"STATE\") | .state.data" | tail -n 1 > "$new_source_state_file") | \


### PR DESCRIPTION
## Description

By using tee to pipe stdout to multiple processes, removing the need to save source output to an intermediate file.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
