### PR TITLE
Rework destination cfg to support both Faros editions

### DIFF
--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -213,7 +213,7 @@ Describe 'building destination config'
                 --dst-stream-prefix 'dummy_prefix' \
                 --debug
 
-        The output should include 'Using destination config: {"cloud_graphql_batch_size":10,"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1"}}'
+        The output should include 'Using destination config: {"edition_configs":{"cloud_graphql_batch_size":10,"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1"}}'
     End
     It 'adds Faros SaaS specific config specified via dst.* flags'
         When run source ../airbyte-local.sh \

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -190,7 +190,7 @@ Describe 'building destination config'
 
         The output should include 'Using destination config: {"feed_cfg":{"inner_cfg":{"y":2,"x":1,"z":{"a":"3","b":4}}}}'
     End
-    It 'adds Faros SaaS specific config when using faros-destination'
+    It 'adds Faros SaaS specific config specified via special flags when using faros-destination'
         When run source ../airbyte-local.sh \
                 --src 'farosai/dummy-source-image' \
                 --dst 'farosai/airbyte-faros-destination' \
@@ -201,6 +201,30 @@ Describe 'building destination config'
                 --debug
 
         The output should include 'Using destination config: {"edition_configs":{"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1"}}'
+    End
+    It 'adds Faros SaaS specific config specified via special flags when using faros-destination while keeping other edition_configs'
+        When run source ../airbyte-local.sh \
+                --src 'farosai/dummy-source-image' \
+                --dst 'farosai/airbyte-faros-destination' \
+                --dst.faros_api_url 'http://faros' \
+                --dst.faros_api_key 'XYZ' \
+                --dst.graph 'g1' \
+                --dst.edition_configs.cloud_graphql_batch_size 10 \
+                --dst-stream-prefix 'dummy_prefix' \
+                --debug
+
+        The output should include 'Using destination config: {"edition_configs":{"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1","cloud_graphql_batch_size":10}}'
+    End
+    It 'adds Faros SaaS specific config specified via dst.* flags'
+        When run source ../airbyte-local.sh \
+                --src 'farosai/dummy-source-image' \
+                --dst 'farosai/airbyte-faros-destination' \
+                --dst.edition_configs '{"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1","cloud_graphql_batch_size":10}' \
+                --dst.edition_configs.check_connection 'true' \
+                --dst-stream-prefix 'dummy_prefix' \
+                --debug
+
+        The output should include 'Using destination config: {"edition_configs":{"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1","cloud_graphql_batch_size":10,"check_connection":true}}'
     End
 End
 

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -213,7 +213,7 @@ Describe 'building destination config'
                 --dst-stream-prefix 'dummy_prefix' \
                 --debug
 
-        The output should include 'Using destination config: {"edition_configs":{"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1","cloud_graphql_batch_size":10}}'
+        The output should include 'Using destination config: {"cloud_graphql_batch_size":10,"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1"}}'
     End
     It 'adds Faros SaaS specific config specified via dst.* flags'
         When run source ../airbyte-local.sh \


### PR DESCRIPTION
## Description

> Provide description here

The current logic to write the destination config handles the Faros destination (`farosai/airbyte-faros-destination`) as a special case. We assume the Faros API URL, API key and graph to have been specified via `--dst.faros_api_url`,`--dst.faros_api_key` and `--dst.graph` respectively, and we use these values + `"edition": "cloud"` as the destination configuration.

This overwrites other values that might have been specified via `--dst.edition_configs` and is also Faros Cloud edition specific (doesn't support the Community Edition case).

This PR fixes the overwriting issue, while keeping the behavior that the special args (`--dst.faros_api_url`,`--dst.faros_api_key` and `--dst.graph`) are still included in the appropriate place in the configuration, for compatibility with clients are already using it. If we could live with a breaking change, we could get rid of this logic and just have clients specify these args according to their paths in the spec (`--dst.edition_configs.faros_api_url`,`--dst.edition_configs.faros_api_key` and `--dst.edition_configs.graph`).

There is no special logic needed to support Faros Community Edition(or Cloud Edition, except for the sake of keeping compatibility). Clients just need to pass the config values as needed. E.g., 

```
--dst.edition_configs '{"edition": "community","hasura_admin_secret": "admin", "hasura_url":"http://localhost:8080"}' \
```

or
```
--dst.edition_configs.edition 'community' \
--dst.edition_configs.hasura_admin_secret 'admin' \
--dst.edition_configs.hasura_url 'http://localhost:8080' \
```
