### PR TITLE
Remove faros-destination specific logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Requirements: `bash`, `docker`, `jq`, `tee`.
    --src.password '<source_password>' \
    --src.url '<source_url>' \
    --dst 'farosai/airbyte-faros-destination' \
-   --dst.faros_api_url '<faros_api_url>' \
-   --dst.faros_api_key '<faros_api_key>' \
-   --dst.graph 'default' \
+   --dst.edition_configs.edition 'cloud' \
+   --dst.edition_configs.api_url '<faros_api_url>' \
+   --dst.edition_configs.api_key '<faros_api_key>' \
+   --dst.edition_configs.graph 'default' \
    --state state.json \
    --check-connection
 ```

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -186,26 +186,6 @@ function writeSrcConfig() {
 }
 
 function writeDstConfig() {
-    if [[ $dst_docker_image == farosai/airbyte-faros-destination* ]]; then
-        if [[ "${dst_config[faros_api_url]}" ]] && [[ "${dst_config[faros_api_key]}" ]] && [[ "${dst_config[graph]}" ]]; then
-            dst_config["edition_configs"]=$(jq -n \
-            --arg faros_api_url "${dst_config[faros_api_url]}" \
-            --arg faros_api_key "${dst_config[faros_api_key]}" \
-            --arg graph "${dst_config[graph]}" \
-            '. +
-            {
-                "edition": "cloud",
-                "api_url": $faros_api_url,
-                "api_key": $faros_api_key,
-                "graph": $graph
-            }
-            ' <<< ${dst_config["edition_configs"]:-"{}"})
-            unset dst_config[faros_api_url]
-            unset dst_config[faros_api_key]
-            unset dst_config[graph]
-        fi
-    fi
-
     writeConfig dst_config "$tempdir/$dst_config_filename"
     debug "Using destination config: $(jq -c < $tempdir/$dst_config_filename)"
 }

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -190,31 +190,6 @@ Describe 'building destination config'
 
         The output should include 'Using destination config: {"feed_cfg":{"inner_cfg":{"y":2,"x":1,"z":{"a":"3","b":4}}}}'
     End
-    It 'adds Faros SaaS specific config specified via special flags when using faros-destination'
-        When run source ../airbyte-local.sh \
-                --src 'farosai/dummy-source-image' \
-                --dst 'farosai/airbyte-faros-destination' \
-                --dst.faros_api_url 'http://faros' \
-                --dst.faros_api_key 'XYZ' \
-                --dst.graph 'g1' \
-                --dst-stream-prefix 'dummy_prefix' \
-                --debug
-
-        The output should include 'Using destination config: {"edition_configs":{"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1"}}'
-    End
-    It 'adds Faros SaaS specific config specified via special flags when using faros-destination while keeping other edition_configs'
-        When run source ../airbyte-local.sh \
-                --src 'farosai/dummy-source-image' \
-                --dst 'farosai/airbyte-faros-destination' \
-                --dst.faros_api_url 'http://faros' \
-                --dst.faros_api_key 'XYZ' \
-                --dst.graph 'g1' \
-                --dst.edition_configs.cloud_graphql_batch_size 10 \
-                --dst-stream-prefix 'dummy_prefix' \
-                --debug
-
-        The output should include 'Using destination config: {"edition_configs":{"cloud_graphql_batch_size":10,"edition":"cloud","api_url":"http://faros","api_key":"XYZ","graph":"g1"}}'
-    End
     It 'adds Faros SaaS specific config specified via dst.* flags'
         When run source ../airbyte-local.sh \
                 --src 'farosai/dummy-source-image' \


### PR DESCRIPTION
## Description

Follow up to https://github.com/faros-ai/airbyte-local-cli/pull/44
We don't need Faros destination specific flags.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [X] Breaking change


