### PR TITLE
Discard check command output lines not containing the status

### DIFF
--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -293,7 +293,7 @@ function loadState() {
 function checkSrc() {
     if ((check_src_connection)); then
         log "Validating connection to source..."
-        connectionStatusInfo=$(docker run --rm -v "$tempdir:/configs" $src_docker_options "$src_docker_image" check --config "/configs/$src_config_filename")
+        connectionStatusInfo=$(docker run -v "$tempdir:/configs" $src_docker_options "$src_docker_image" check --config "/configs/$src_config_filename" | grep "CONNECTION_STATUS")
         connectionStatus=$(echo "$connectionStatusInfo" | jq -r '.connectionStatus.status')
         if [[ "$connectionStatus" != 'SUCCEEDED' ]]; then
             err $(echo "$connectionStatusInfo" | jq -r '.connectionStatus.message')


### PR DESCRIPTION
## Description

Found that the check connection command sometimes outputs more than just the status. E.g., for `airbyte/source-gitlab` I got ```{"type": "LOG", "log": {"level": "INFO", "message": "Check succeeded"}}
{"type": "CONNECTION_STATUS", "connectionStatus": {"status": "SUCCEEDED"}}```

Skips the lines which do not contain the `CONNECTION_STATUS` so that we check for `status eq SUCCEEDED` in the right json object.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
