### PR TITLE
Bash4 passing associative arrays

### DIFF
--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -201,7 +201,8 @@ function writeDstConfig() {
 }
 
 function writeConfig() {
-    local -n config=$1
+    var=$(declare -p "$1")
+    eval "declare -A config=${var#*=}"
     # Inspired by https://stackoverflow.com/questions/44792241/constructing-a-json-hash-from-a-bash-associative-array
     for key in "${!config[@]}"; do
         printf '%s\0%s\0' "$key" "${config[$key]}"


### PR DESCRIPTION
## Description

`local -n` was introduced in Bash version 4.3 however we only enforce that Bash 4 be installed. This change supports passing associative arrays to functions in a Bash 4 supported way.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change