### PR TITLE
Include supported sync modes when overriding src catalog

### DIFF
--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -238,7 +238,7 @@ function writeSrcCatalog() {
                   | select($src_catalog_overrides[.name].disabled != true)
                   | .incremental = ((.supported_sync_modes|contains(["incremental"])) and ($src_catalog_overrides[.name].sync_mode != "full_refresh") and ($full_refresh != "true"))
                   | {
-                      stream: {name: .name, json_schema: {}},
+                      stream: {name: .name, supported_sync_modes: .supported_sync_modes, json_schema: {}},
                       sync_mode: (if .incremental then "incremental" else "full_refresh" end),
                       destination_sync_mode: ($src_catalog_overrides[.name].destination_sync_mode? // if .incremental then "append" else "overwrite" end)
                     }

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -98,7 +98,7 @@ Describe 'building source catalog'
                 --src.feed_cfg.feed_name 'jira-feed' \
                 --src.feed_cfg.feed_path 'tms/jira-feed' \
                 --debug
-        The output should include 'Using source configured catalog: {"streams":[{"stream":{"name":"faros_feed","json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
+        The output should include 'Using source configured catalog: {"streams":[{"stream":{"name":"faros_feed","supported_sync_modes":["full_refresh","incremental"],"json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
     End
     It 'full-refresh flag forces full refresh and overwrite mode'
         When run source ../airbyte-local.sh \
@@ -108,7 +108,7 @@ Describe 'building source catalog'
                 --src.feed_cfg.feed_path 'tms/jira-feed' \
                 --full-refresh \
                 --debug
-        The output should include 'Using source configured catalog: {"streams":[{"stream":{"name":"faros_feed","json_schema":{}},"sync_mode":"full_refresh","destination_sync_mode":"overwrite"}]}'
+        The output should include 'Using source configured catalog: {"streams":[{"stream":{"name":"faros_feed","supported_sync_modes":["full_refresh","incremental"],"json_schema":{}},"sync_mode":"full_refresh","destination_sync_mode":"overwrite"}]}'
     End
     It 'uses src-catalog-overrides sync mode'
         When run source ../airbyte-local.sh \
@@ -118,7 +118,7 @@ Describe 'building source catalog'
                 --src.feed_cfg.feed_path 'tms/jira-feed' \
                 --src-catalog-overrides '{"faros_feed": {"sync_mode": "full_refresh"}}' \
                 --debug
-        The output should include 'Using source configured catalog: {"streams":[{"stream":{"name":"faros_feed","json_schema":{}},"sync_mode":"full_refresh","destination_sync_mode":"overwrite"}]}'
+        The output should include 'Using source configured catalog: {"streams":[{"stream":{"name":"faros_feed","supported_sync_modes":["full_refresh","incremental"],"json_schema":{}},"sync_mode":"full_refresh","destination_sync_mode":"overwrite"}]}'
     End
     It 'ignores disabled streams'
         When run source ../airbyte-local.sh \
@@ -243,7 +243,7 @@ Describe 'building destination catalog'
                 --dst-stream-prefix 'dummy_prefix__' \
                 --debug
 
-        The output should include 'Using destination configured catalog: {"streams":[{"stream":{"name":"dummy_prefix__faros_feed","json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
+        The output should include 'Using destination configured catalog: {"streams":[{"stream":{"name":"dummy_prefix__faros_feed","supported_sync_modes":["full_refresh","incremental"],"json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
     End
 
     It 'creates stream prefix when source and destination are Faros connectors'
@@ -252,7 +252,7 @@ Describe 'building destination catalog'
                 --dst 'farosai/airbyte-faros-destination' \
                 --debug
 
-        The output should include 'Using destination configured catalog: {"streams":[{"stream":{"name":"mydummysourcesrc__dummy_source__faros_feed","json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
+        The output should include 'Using destination configured catalog: {"streams":[{"stream":{"name":"mydummysourcesrc__dummy_source__faros_feed","supported_sync_modes":["full_refresh","incremental"],"json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
     End
     It 'creates stream prefix including connection_name when source and destination are Faros connectors'
         When run source ../airbyte-local.sh \
@@ -261,7 +261,7 @@ Describe 'building destination catalog'
                 --connection-name 'connectionXYZ' \
                 --debug
 
-        The output should include 'Using destination configured catalog: {"streams":[{"stream":{"name":"connectionXYZ__dummy_source__faros_feed","json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
+        The output should include 'Using destination configured catalog: {"streams":[{"stream":{"name":"connectionXYZ__dummy_source__faros_feed","supported_sync_modes":["full_refresh","incremental"],"json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
     End
     It 'fails if missing stream prefix when using Faros destination and non-Faros source'
         When run source ../airbyte-local.sh \
@@ -278,6 +278,6 @@ Describe 'building destination catalog'
                 --dst 'airbytehq/dummy-destination-image' \
                 --debug
 
-        The output should include 'Using destination configured catalog: {"streams":[{"stream":{"name":"faros_feed","json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
+        The output should include 'Using destination configured catalog: {"streams":[{"stream":{"name":"faros_feed","supported_sync_modes":["full_refresh","incremental"],"json_schema":{}},"sync_mode":"incremental","destination_sync_mode":"append"}]}'
     End
 End


### PR DESCRIPTION
I get the following error if I use `--src-catalog-overrides` with my source:

```
[SRC]: 14:06:30 - {"type":"LOG","log":{"level":"FATAL","message":"2 validation errors for ConfiguredAirbyteCatalog\nstreams -> 0 -> stream -> supported_sync_modes\n  field required (type=value_error.missing)\nstreams -> 1 -> stream -> supported_sync_modes\n  field required (type=value_error.missing)\nTraceback (most recent call last):\n  File \"/airbyte/integration_code/main.py\", line 13, in <module>\n    launch(source, sys.argv[1:])\n  File \"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 131, in launch\n    for message in source_entrypoint.run(parsed_args):\n  File \"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 119, in run\n    config_catalog = self.source.read_catalog(parsed_args.catalog)\n  File \"/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/source.py\", line 89, in read_catalog\n    return ConfiguredAirbyteCatalog.parse_obj(self._read_json_file(catalog_path))\n  File \"pydantic/main.py\", line 521, in pydantic.main.BaseModel.parse_obj\n  File \"pydantic/main.py\", line 341, in pydantic.main.BaseModel.__init__\npydantic.error_wrappers.ValidationError: 2 validation errors for ConfiguredAirbyteCatalog\nstreams -> 0 -> stream -> supported_sync_modes\n  field required (type=value_error.missing)\nstreams -> 1 -> stream -> supported_sync_modes\n  field required (type=value_error.missing)"}}
```

Adding `supported_sync_modes` back into the stream's catalog entry fixed it.