### PR TITLE
Add support for writing destination input to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.json
+/.idea

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 ## Arguments
 
 | Argument                          | Required | Description                                                                                       |
-| --------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
+|-----------------------------------| -------- |---------------------------------------------------------------------------------------------------|
 | --src \<image\>                   | Yes      | Airbyte source Docker image                                                                       |
 | --dst \<image\>                   | Yes      | Airbyte destination Docker image                                                                  |
 | --src.\<key\> \<value\>           |          | Append `"key": "value"` into the source config \*                                                 |
@@ -60,6 +60,7 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 | --check-connection                |          | Validate the Airbyte source connection                                                            |
 | --full-refresh                    |          | Force source full_refresh and destination overwrite mode                                          |
 | --state \<path\>                  |          | Override state file path for incremental sync                                                     |
+| --src-output-file \<path\>        |          | Write source output as a file (handy for debugging)                                               |
 | --src-catalog-overrides \<json\>  |          | JSON string of sync mode overrides. See [overriding default catalog](#overriding-default-catalog) |
 | --src-catalog-file \<path\>       |          | Source catalog file path                                                                          |
 | --src-catalog-json \<json\>       |          | Source catalog as a JSON string                                                                   |

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -48,7 +48,7 @@ function help() {
     echo "--check-connection                Validate the Airbyte source connection"
     echo "--full-refresh                    Force full_refresh and overwrite mode"
     echo "--state <path>                    Override state file path for incremental sync"
-    echo "--output <path>                   Write destination input as a file"
+    echo "--src-output-file <path>          Write source output as a file (handy for debugging)"
     echo "--src-catalog-overrides <json>    JSON string of sync mode overrides"
     echo "--src-catalog-file <path>         Source catalog file path"
     echo "--src-catalog-json <json>         Source catalog as a JSON string"
@@ -98,7 +98,7 @@ function parseFlags() {
             --state)
                 src_state_filepath="$2"
                 shift 2 ;;
-            --output)
+            --src-output-file)
                 output_filepath="$2"
                 shift 2 ;;
             --src-catalog-overrides)
@@ -326,6 +326,7 @@ function readSrc() {
 }
 
 function sync() {
+    debug "Writing source output to $output_filepath"
     new_source_state_file="$tempdir/new_state.json"
     readSrc |
         tee >(jq -cCR --unbuffered 'fromjson? | select(.type != "RECORD" and .type != "STATE")' |

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -58,6 +58,29 @@ Describe 'building source config'
     End
 End
 
+Describe 'writing source output'
+    # Makes the docker command a noop since we don't need it for these tests
+    docker() {
+        true
+    }
+
+    It 'writes source output to file'
+        When run source ../airbyte-local.sh \
+                --src 'farosai/dummy-source-image' \
+                --dst 'farosai/dummy-destination-image' \
+                --src-output-file '/tmp/out.txt' \
+                --debug
+        The output should include 'Writing source output to /tmp/out.txt'
+    End
+    It 'does not write source output'
+        When run source ../airbyte-local.sh \
+                --src 'farosai/dummy-source-image' \
+                --dst 'farosai/dummy-destination-image' \
+                --debug
+        The output should include 'Writing source output to /dev/null'
+    End
+End
+
 Describe 'building source catalog'
     # Mock the docker command that invokes the Airbyte source "discover"
     docker() {


### PR DESCRIPTION
## Description

Added optional `--output <path>` program option.  If specified, the destination container's `stdin` is `tee`'ed to the specified file.  This is very useful for capturing streams for debugging, etc.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
