### PR TITLE
Redact secrets when debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 | --src-docker-options "\<string\>" |          | Set additional options to pass to the `docker run <src>` command                                  |
 | --dst-docker-options "\<string\>" |          | Set additional options to pass to the `docker run <dst>` command                                  |
 | --debug                           |          | Enable debug logging                                                                              |
-| --debug-secrets                   |          | Enable debug logging with visible secrets                                                         |
 
 **Note**: when passing an array value for a parameter specify it as a json array, for example:
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,12 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 | --state \<path\>                  |          | Override state file path for incremental sync                                                     |
 | --src-output-file \<path\>        |          | Write source output as a file (handy for debugging)                                               |
 | --src-catalog-overrides \<json\>  |          | JSON string of sync mode overrides. See [overriding default catalog](#overriding-default-catalog) |
+| --src-config-file \<path\>        |          | Source config file path                                                                           |
+| --src-config-json \<json\>        |          | Source config as a JSON string                                                                    |
 | --src-catalog-file \<path\>       |          | Source catalog file path                                                                          |
 | --src-catalog-json \<json\>       |          | Source catalog as a JSON string                                                                   |
+| --dst-config-file \<path\>        |          | Destination config file path                                                                      |
+| --dst-config-json \<json\>        |          | Destination config as a JSON string                                                               |
 | --dst-catalog-file \<path\>       |          | Destination catalog file path                                                                     |
 | --dst-catalog-json \<json\>       |          | Destination catalog as a JSON string                                                              |
 | --dst-stream-prefix \<prefix\>    |          | Destination stream prefix                                                                         |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 ## Arguments
 
 | Argument                          | Required | Description                                                                                       |
-|-----------------------------------| -------- |---------------------------------------------------------------------------------------------------|
+| --------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | --src \<image\>                   | Yes      | Airbyte source Docker image                                                                       |
 | --dst \<image\>                   | Yes      | Airbyte destination Docker image                                                                  |
 | --src.\<key\> \<value\>           |          | Append `"key": "value"` into the source config \*                                                 |
@@ -79,6 +79,7 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 | --src-docker-options "\<string\>" |          | Set additional options to pass to the `docker run <src>` command                                  |
 | --dst-docker-options "\<string\>" |          | Set additional options to pass to the `docker run <dst>` command                                  |
 | --debug                           |          | Enable debug logging                                                                              |
+| --debug-secrets                   |          | Enable debug logging with visible secrets                                                         |
 
 **Note**: when passing an array value for a parameter specify it as a json array, for example:
 

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -221,7 +221,10 @@ function writeDstConfig() {
     debug "Using destination config: $(redactConfigSecrets "$(jq -c < $tempdir/$dst_config_filename)" "$(specDst)")"
 }
 
-# constructs paths to fields that should be redacted from spec and then redacts them in the config
+# Constructs paths to fields that should be redacted using Airbyte spec and then redacts them from the config
+# $1      - Config with secrets to redact
+# $2      - Airbyte spec that defines which fields are "airbyte_secret"
+# returns - Config with redacted secrets
 function redactConfigSecrets() {
     loggable_config="$1"
     config_properties="$(echo "$2" | jq -r '.spec.connectionSpecification.properties')"

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -228,7 +228,7 @@ function writeSrcConfig() {
 }
 
 function redactSrcConfigSecrets() {
-    keys_to_redact=$(specSrc | jq -r '.spec.connectionSpecification.properties | to_entries | [.[] | select(.value.airbyte_secret) | .key]')
+    keys_to_redact=$(specSrc | jq -r '.spec.connectionSpecification.properties | to_entries | map(select(.value.airbyte_secret).key)')
     loggable_src_config="$(jq -c --argjson redact "$keys_to_redact" '. |= with_entries( .value = if ([.key] | inside($redact)) then "REDACTED" else .value end )' <<< $loggable_src_config)"
 }
 

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -221,6 +221,7 @@ function writeDstConfig() {
     debug "Using destination config: $(redactConfigSecrets "$(jq -c < $tempdir/$dst_config_filename)" "$(specDst)")"
 }
 
+# constructs paths to fields that should be redacted from spec and then redacts them in the config
 function redactConfigSecrets() {
     loggable_config="$1"
     config_properties="$(echo "$2" | jq -r '.spec.connectionSpecification.properties')"

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -213,12 +213,16 @@ function validateInput() {
 
 function writeSrcConfig() {
     writeConfig src_config "$tempdir/$src_config_filename"
-    debug "Using source config: $(redactConfigSecrets "$(jq -c < $tempdir/$src_config_filename)" "$(specSrc)")"
+    if ((debug)); then
+        debug "Using source config: $(redactConfigSecrets "$(jq -c < $tempdir/$src_config_filename)" "$(specSrc)")"
+    fi
 }
 
 function writeDstConfig() {
     writeConfig dst_config "$tempdir/$dst_config_filename"
-    debug "Using destination config: $(redactConfigSecrets "$(jq -c < $tempdir/$dst_config_filename)" "$(specDst)")"
+    if ((debug)); then
+        debug "Using destination config: $(redactConfigSecrets "$(jq -c < $tempdir/$dst_config_filename)" "$(specDst)")"
+    fi
 }
 
 # Constructs paths to fields that should be redacted using Airbyte spec and then redacts them from the config

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -232,7 +232,10 @@ function writeDstConfig() {
 function redactConfigSecrets() {
     loggable_config="$1"
     config_properties="$(echo "$2" | jq -r '.spec.connectionSpecification.properties')"
-    paths_to_redact=($(jq -c --stream 'if .[0][-1] == "airbyte_secret" and .[1] then .[0] else null end | select(. != null) | .[0:-1] | map(select(. != "properties"))' <<< "$config_properties"))
+    paths_to_redact=($(jq -c --stream 'if .[0][-1] == "airbyte_secret" and .[1] then .[0] else null end 
+                                       | select(. != null) 
+                                       | .[0:-1] 
+                                       | map(select(. != "properties" and . != "oneOf" and (.|tostring|test("^\\d+$")|not)))' <<< "$config_properties"))
     for path in "${paths_to_redact[@]}"; do
         loggable_config="$(jq -c --argjson path "$path" 'if getpath($path) != null then setpath($path; "REDACTED") else . end' <<< "$loggable_config")"
     done

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -229,7 +229,7 @@ function writeSrcConfig() {
 
 function redactSrcConfigSecrets() {
     keys_to_redact=$(specSrc | jq -r '.spec.connectionSpecification.properties | to_entries | [.[] | select(.value.airbyte_secret) | .key]')
-    loggable_src_config="$(jq -r --argjson redact "$keys_to_redact" '. |= with_entries( .value = if ([.key] | inside($redact)) then "REDACTED" else .value end )' <<< $loggable_src_config)"
+    loggable_src_config="$(jq -c --argjson redact "$keys_to_redact" '. |= with_entries( .value = if ([.key] | inside($redact)) then "REDACTED" else .value end )' <<< $loggable_src_config)"
 }
 
 function writeDstConfig() {

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -235,8 +235,11 @@ function redactConfigSecrets() {
     paths_to_redact=($(jq -c --stream 'if .[0][-1] == "airbyte_secret" and .[1] then .[0] else null end 
                                        | select(. != null) 
                                        | .[0:-1] 
-                                       | map(select(. != "properties" and . != "oneOf" and (.|tostring|test("^\\d+$")|not)))' <<< "$config_properties"))
-    for path in "${paths_to_redact[@]}"; do
+                                       | map(select(. != "properties" and 
+                                                    . != "oneOf" and
+                                                    . != "anyOf" and
+                                                    (.|tostring|test("^\\d+$")|not)))' <<< "$config_properties"))
+    for path in "${paths_to_redact[@]}"; do\
         loggable_config="$(jq -c --argjson path "$path" 'if getpath($path) != null then setpath($path; "REDACTED") else . end' <<< "$loggable_config")"
     done
     echo "$loggable_config"

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -102,13 +102,18 @@ Describe 'redacting source config secrets'
     It 'redacts airbyte_secret fields'
         When run source ../airbyte-local.sh \
                 --src 'farosai/dummy-source-image' \
-                --src-only \
+                --dst 'farosai/dummy-destination-image' \
                 --src.nested_object.other 'bar' \
                 --src.nested_object.secret 'SHOULD_BE_REDACTED!!!' \
                 --src.other 'foo' \
                 --src.secret 'SHOULD_BE_REDACTED!!!' \
+                --dst.nested_object.other 'bar' \
+                --dst.nested_object.secret 'SHOULD_BE_REDACTED!!!' \
+                --dst.other 'foo' \
+                --dst.secret 'SHOULD_BE_REDACTED!!!' \
                 --debug
-        The output should include 'Using source config: {"nested_object":{"secret":"REDACTED","other":"bar"},"secret":"REDACTED","other":"foo"}'
+        The output should include 'Using source config: {"nested_object":{"secret":"REDACTED","other":"bar"},"secret":"REDACTED","other":"foo"}' 
+        The output should include 'Using destination config: {"nested_object":{"secret":"REDACTED","other":"bar"},"secret":"REDACTED","other":"foo"}'
     End
 End
 

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -105,10 +105,10 @@ Describe 'redacting source config secrets'
         When run source ../airbyte-local.sh \
                 --src 'farosai/dummy-source-image' \
                 --dst 'farosai/dummy-destination-image' \
-                --src-config-json '{"nestedObj":{"secret":"SHOULD_BE_REDACTED!!!","other":"bar"},"anyOfObj":{"g":"SHOULD_BE_REDACTED!!!","h":"h"},"secret":"SHOULD_BE_REDACTED!!!","oneOfObj":{"c":"SHOULD_BE_REDACTED!!!","d":"d"},"other":"foo"}' \
+                --src-config-json '{"nestedObj":{"secret":"SHOULD_BE_REDACTED!!!","other":"bar"},"anyOfObj":{"e":"SHOULD_BE_REDACTED!!!","f":"f"},"secret":"SHOULD_BE_REDACTED!!!","oneOfObj":{"a":"SHOULD_BE_REDACTED!!!","b":"b"},"other":"foo"}' \
                 --dst-config-json '{"nestedObj":{"secret":"SHOULD_BE_REDACTED!!!","other":"bar"},"anyOfObj":{"g":"SHOULD_BE_REDACTED!!!","h":"h"},"secret":"SHOULD_BE_REDACTED!!!","oneOfObj":{"c":"SHOULD_BE_REDACTED!!!","d":"d"},"other":"foo"}' \
                 --debug
-        The output should include 'Using source config: {"nestedObj":{"secret":"REDACTED","other":"bar"},"anyOfObj":{"g":"REDACTED","h":"h"},"secret":"REDACTED","oneOfObj":{"c":"REDACTED","d":"d"},"other":"foo"}' 
+        The output should include 'Using source config: {"nestedObj":{"secret":"REDACTED","other":"bar"},"anyOfObj":{"e":"REDACTED","f":"f"},"secret":"REDACTED","oneOfObj":{"a":"REDACTED","b":"b"},"other":"foo"}' 
         The output should include 'Using destination config: {"nestedObj":{"secret":"REDACTED","other":"bar"},"anyOfObj":{"g":"REDACTED","h":"h"},"secret":"REDACTED","oneOfObj":{"c":"REDACTED","d":"d"},"other":"foo"}'
     End
 End

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -70,14 +70,17 @@ Describe 'redacting source config secrets'
                     "connectionSpecification": {
                         "properties": {
                             "nested_object": {
-                                "other": {
-                                    "type": "string",
-                                    "title": "NonSecret"
-                                },
-                                "secret": {
-                                    "type": "string",
-                                    "title": "Secret",
-                                    "airbyte_secret": true
+                                "type": "object",
+                                "properties": {
+                                    "other": {
+                                        "type": "string",
+                                        "title": "NonSecret"
+                                    },
+                                    "secret": {
+                                        "type": "string",
+                                        "title": "Secret",
+                                        "airbyte_secret": true
+                                    }
                                 }
                             },
                             "other": {

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -72,24 +72,26 @@ Describe 'redacting source config secrets'
                             "nested_object": {
                                 "type": "object",
                                 "properties": {
-                                    "other": {
-                                        "type": "string",
-                                        "title": "NonSecret"
-                                    },
+                                    "other": {},
                                     "secret": {
-                                        "type": "string",
-                                        "title": "Secret",
                                         "airbyte_secret": true
                                     }
                                 }
                             },
-                            "other": {
-                                "type": "string",
-                                "title": "NonSecret"
+                            "oneOf_object": {
+                                "oneOf": [
+                                    {"properties":{"a":{"airbyte_secret": true},"b":{}}},
+                                    {"properties":{"c":{"airbyte_secret": true},"d":{}}}
+                                ]
                             },
+                            "anyOf_object": {
+                                "anyOf": [
+                                    {"properties":{"e":{"airbyte_secret": true},"f":{}}},
+                                    {"properties":{"g":{"airbyte_secret": true},"h":{}}}
+                                ]
+                            },
+                            "other": {},
                             "secret": {
-                                "type": "string",
-                                "title": "Secret",
                                 "airbyte_secret": true
                             }
                         }
@@ -105,15 +107,23 @@ Describe 'redacting source config secrets'
                 --dst 'farosai/dummy-destination-image' \
                 --src.nested_object.other 'bar' \
                 --src.nested_object.secret 'SHOULD_BE_REDACTED!!!' \
+                --src.oneOf_object.a 'SHOULD_BE_REDACTED!!!' \
+                --src.oneOf_object.b 'b' \
+                --src.anyOf_object.e 'SHOULD_BE_REDACTED!!!' \
+                --src.anyOf_object.f 'f' \
                 --src.other 'foo' \
                 --src.secret 'SHOULD_BE_REDACTED!!!' \
                 --dst.nested_object.other 'bar' \
                 --dst.nested_object.secret 'SHOULD_BE_REDACTED!!!' \
+                --dst.oneOf_object.c 'SHOULD_BE_REDACTED!!!' \
+                --dst.oneOf_object.d 'd' \
+                --dst.anyOf_object.g 'SHOULD_BE_REDACTED!!!' \
+                --dst.anyOf_object.h 'h' \
                 --dst.other 'foo' \
                 --dst.secret 'SHOULD_BE_REDACTED!!!' \
                 --debug
-        The output should include 'Using source config: {"nested_object":{"secret":"REDACTED","other":"bar"},"secret":"REDACTED","other":"foo"}' 
-        The output should include 'Using destination config: {"nested_object":{"secret":"REDACTED","other":"bar"},"secret":"REDACTED","other":"foo"}'
+        The output should include 'Using source config: {"nested_object":{"secret":"REDACTED","other":"bar"},"anyOf_object":{"f":"f","e":"REDACTED"},"secret":"REDACTED","oneOf_object":{"a":"REDACTED","b":"b"},"other":"foo"}' 
+        The output should include 'Using destination config: {"nested_object":{"secret":"REDACTED","other":"bar"},"anyOf_object":{"h":"h","g":"REDACTED"},"secret":"REDACTED","oneOf_object":{"d":"d","c":"REDACTED"},"other":"foo"}'
     End
 End
 

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -75,7 +75,7 @@ Describe 'redacting source config secrets'
                                     {"properties":{"g":{"airbyte_secret": true},"h":{}}}
                                 ]
                             },
-                            "nestedObjObj": {
+                            "nestedObj": {
                                 "type": "object",
                                 "properties": {
                                     "other": {},
@@ -105,25 +105,11 @@ Describe 'redacting source config secrets'
         When run source ../airbyte-local.sh \
                 --src 'farosai/dummy-source-image' \
                 --dst 'farosai/dummy-destination-image' \
-                --src.anyOfObj.e 'SHOULD_BE_REDACTED!!!' \
-                --src.anyOfObj.f 'f' \
-                --src.nestedObjObj.other 'bar' \
-                --src.nestedObj.secret 'SHOULD_BE_REDACTED!!!' \
-                --src.oneOfObj.a 'SHOULD_BE_REDACTED!!!' \
-                --src.oneOfObj.b 'b' \
-                --src.other 'foo' \
-                --src.secret 'SHOULD_BE_REDACTED!!!' \
-                --dst.anyOfObj.g 'SHOULD_BE_REDACTED!!!' \
-                --dst.anyOfObj.h 'h' \
-                --dst.nestedObj.other 'bar' \
-                --dst.nestedObj.secret 'SHOULD_BE_REDACTED!!!' \
-                --dst.oneOfObj.c 'SHOULD_BE_REDACTED!!!' \
-                --dst.oneOfObj.d 'd' \
-                --dst.other 'foo' \
-                --dst.secret 'SHOULD_BE_REDACTED!!!' \
+                --src-config-json '{"nestedObj":{"secret":"SHOULD_BE_REDACTED!!!","other":"bar"},"anyOfObj":{"g":"SHOULD_BE_REDACTED!!!","h":"h"},"secret":"SHOULD_BE_REDACTED!!!","oneOfObj":{"c":"SHOULD_BE_REDACTED!!!","d":"d"},"other":"foo"}' \
+                --dst-config-json '{"nestedObj":{"secret":"SHOULD_BE_REDACTED!!!","other":"bar"},"anyOfObj":{"g":"SHOULD_BE_REDACTED!!!","h":"h"},"secret":"SHOULD_BE_REDACTED!!!","oneOfObj":{"c":"SHOULD_BE_REDACTED!!!","d":"d"},"other":"foo"}' \
                 --debug
-        The output should include 'Using source config: {"nestedObj":{"secret":"SHOULD_BE_REDACTED!!!"},"anyOfObj":{"f":"f","e":"REDACTED"},"secret":"REDACTED","oneOfObj":{"a":"REDACTED","b":"b"},"nestedObjObj":{"other":"bar"},"other":"foo"}' 
-        The output should include 'Using destination config: {"nestedObj":{"secret":"SHOULD_BE_REDACTED!!!","other":"bar"},"anyOfObj":{"g":"REDACTED","h":"h"},"secret":"REDACTED","oneOfObj":{"c":"REDACTED","d":"d"},"other":"foo"}'
+        The output should include 'Using source config: {"nestedObj":{"secret":"REDACTED","other":"bar"},"anyOfObj":{"g":"REDACTED","h":"h"},"secret":"REDACTED","oneOfObj":{"c":"REDACTED","d":"d"},"other":"foo"}' 
+        The output should include 'Using destination config: {"nestedObj":{"secret":"REDACTED","other":"bar"},"anyOfObj":{"g":"REDACTED","h":"h"},"secret":"REDACTED","oneOfObj":{"c":"REDACTED","d":"d"},"other":"foo"}'
     End
 End
 

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -69,7 +69,13 @@ Describe 'redacting source config secrets'
                 "spec": {
                     "connectionSpecification": {
                         "properties": {
-                            "nested_object": {
+                            "anyOfObj": {
+                                "anyOf": [
+                                    {"properties":{"e":{"airbyte_secret": true},"f":{}}},
+                                    {"properties":{"g":{"airbyte_secret": true},"h":{}}}
+                                ]
+                            },
+                            "nestedObjObj": {
                                 "type": "object",
                                 "properties": {
                                     "other": {},
@@ -78,16 +84,10 @@ Describe 'redacting source config secrets'
                                     }
                                 }
                             },
-                            "oneOf_object": {
+                            "oneOfObj": {
                                 "oneOf": [
                                     {"properties":{"a":{"airbyte_secret": true},"b":{}}},
                                     {"properties":{"c":{"airbyte_secret": true},"d":{}}}
-                                ]
-                            },
-                            "anyOf_object": {
-                                "anyOf": [
-                                    {"properties":{"e":{"airbyte_secret": true},"f":{}}},
-                                    {"properties":{"g":{"airbyte_secret": true},"h":{}}}
                                 ]
                             },
                             "other": {},
@@ -105,25 +105,25 @@ Describe 'redacting source config secrets'
         When run source ../airbyte-local.sh \
                 --src 'farosai/dummy-source-image' \
                 --dst 'farosai/dummy-destination-image' \
-                --src.nested_object.other 'bar' \
-                --src.nested_object.secret 'SHOULD_BE_REDACTED!!!' \
-                --src.oneOf_object.a 'SHOULD_BE_REDACTED!!!' \
-                --src.oneOf_object.b 'b' \
-                --src.anyOf_object.e 'SHOULD_BE_REDACTED!!!' \
-                --src.anyOf_object.f 'f' \
+                --src.anyOfObj.e 'SHOULD_BE_REDACTED!!!' \
+                --src.anyOfObj.f 'f' \
+                --src.nestedObjObj.other 'bar' \
+                --src.nestedObj.secret 'SHOULD_BE_REDACTED!!!' \
+                --src.oneOfObj.a 'SHOULD_BE_REDACTED!!!' \
+                --src.oneOfObj.b 'b' \
                 --src.other 'foo' \
                 --src.secret 'SHOULD_BE_REDACTED!!!' \
-                --dst.nested_object.other 'bar' \
-                --dst.nested_object.secret 'SHOULD_BE_REDACTED!!!' \
-                --dst.oneOf_object.c 'SHOULD_BE_REDACTED!!!' \
-                --dst.oneOf_object.d 'd' \
-                --dst.anyOf_object.g 'SHOULD_BE_REDACTED!!!' \
-                --dst.anyOf_object.h 'h' \
+                --dst.anyOfObj.g 'SHOULD_BE_REDACTED!!!' \
+                --dst.anyOfObj.h 'h' \
+                --dst.nestedObj.other 'bar' \
+                --dst.nestedObj.secret 'SHOULD_BE_REDACTED!!!' \
+                --dst.oneOfObj.c 'SHOULD_BE_REDACTED!!!' \
+                --dst.oneOfObj.d 'd' \
                 --dst.other 'foo' \
                 --dst.secret 'SHOULD_BE_REDACTED!!!' \
                 --debug
-        The output should include 'Using source config: {"nested_object":{"secret":"REDACTED","other":"bar"},"anyOf_object":{"f":"f","e":"REDACTED"},"secret":"REDACTED","oneOf_object":{"a":"REDACTED","b":"b"},"other":"foo"}' 
-        The output should include 'Using destination config: {"nested_object":{"secret":"REDACTED","other":"bar"},"anyOf_object":{"h":"h","g":"REDACTED"},"secret":"REDACTED","oneOf_object":{"d":"d","c":"REDACTED"},"other":"foo"}'
+        The output should include 'Using source config: {"nestedObj":{"secret":"SHOULD_BE_REDACTED!!!"},"anyOfObj":{"f":"f","e":"REDACTED"},"secret":"REDACTED","oneOfObj":{"a":"REDACTED","b":"b"},"nestedObjObj":{"other":"bar"},"other":"foo"}' 
+        The output should include 'Using destination config: {"nestedObj":{"secret":"SHOULD_BE_REDACTED!!!","other":"bar"},"anyOfObj":{"g":"REDACTED","h":"h"},"secret":"REDACTED","oneOfObj":{"c":"REDACTED","d":"d"},"other":"foo"}'
     End
 End
 

--- a/test/spec/airbyte-local_spec.sh
+++ b/test/spec/airbyte-local_spec.sh
@@ -73,12 +73,12 @@ Describe 'redacting source config secrets'
                         "required": ["secret", "non_secret"],
                         "additionalProperties": true,
                         "properties": {
-                            "secret": {
+                            "_secret": {
                                 "type": "string",
                                 "title": "Secret",
                                 "airbyte_secret": true
                             },
-                            "non_secret": {
+                            "other": {
                                 "type": "string",
                                 "title": "NonSecret"
                             }
@@ -94,10 +94,10 @@ Describe 'redacting source config secrets'
         When run source ../airbyte-local.sh \
                 --src 'farosai/dummy-source-image' \
                 --src-only \
-                --src.secret 'SHOULD_BE_REDACTED!!!' \
-                --src.non_secret 'foo' \
+                --src._secret 'SHOULD_BE_REDACTED!!!' \
+                --src.other 'foo' \
                 --debug
-        The output should include 'Using source config: {"non_secret":"foo","secret":"REDACTED"}'
+        The output should include 'Using source config: {"_secret":"REDACTED","other":"foo"}'
     End
 End
 


### PR DESCRIPTION
## Description

When using `--debug`, the secrets provided are output into the logs. They should be redacted. Which fields should be redacted is determined by which properties are `airbyte_secret` in the source/destination spec 

![Screenshot 2023-03-17 at 11 28 48 AM](https://user-images.githubusercontent.com/10718300/225988937-52a62a0f-8d3b-4b68-9992-460ddb12789a.png)

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
