### PR TITLE
Add options to run the src/dst wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,19 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 
 **Note**: The `src.*` and `dst.*` arguments will differ depending on the source and destination being used.
 
-## Configuring source/destination using a wizard (Faros sources/destination only)
+## Configuring source/destination using a wizard
 
-Instead of passing `src.*` and `dst.*`, it is possible to invoke a configuration wizard for the source 
+**Note**: Faros Feeds Source and/or Faros Destination only
+
+Instead of passing `src.*` and `dst.*`, it is possible to invoke a configuration wizard for the Faros source 
 and/or destination:
 
 ```
-./airbyte-local.sh  \
---src 'farosai/airbyte-faros-feeds-source'  \
---src-wizard \
---dst 'farosai/airbyte-faros-destination' \
---dst-wizard
+./airbyte-local.sh \
+  --src 'farosai/airbyte-faros-feeds-source' \
+  --src-wizard \
+  --dst 'farosai/airbyte-faros-destination' \
+  --dst-wizard
 ```
 
 ## Arguments

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 
 **Note**: The `src.*` and `dst.*` arguments will differ depending on the source and destination being used.
 
-## Configuring source/destination using a wizard
+## Configuring Faros source/destination using a wizard
 
 **Note**: Faros Feeds Source and/or Faros Destination only
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 
 **Note**: The `src.*` and `dst.*` arguments will differ depending on the source and destination being used.
 
+## Configuring source/destination using a wizard (Faros sources/destination only)
+
+Instead of passing `src.*` and `dst.*`, it is possible to invoke a configuration wizard for the source 
+and/or destination:
+
+```
+./airbyte-local.sh  \
+--src 'farosai/airbyte-faros-feeds-source'  \
+--src-wizard \
+--dst 'farosai/airbyte-faros-destination' \
+--dst-wizard
+```
+
 ## Arguments
 
 | Argument                          | Required | Description                                                                                       |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Or with [Faros Community Edition](https://github.com/faros-ai/faros-community-ed
 | --dst-stream-prefix \<prefix\>    |          | Destination stream prefix                                                                         |
 | --no-src-pull                     |          | Skip pulling Airbyte source image                                                                 |
 | --no-dst-pull                     |          | Skip pulling Airbyte destination image                                                            |
+| --src-wizard                      |          | Run the Airbyte source configuration  wizard                                                                 |
+| --dst-wizard                      |          | Run the Airbyte destination configuration  wizard                                                            |
 | --src-only                        |          | Only run the Airbyte source                                                                       |
 | --dst-only \<file\>               |          | Use a file for destination input instead of a source                                              |
 | --connection-name                 |          | Connection name used in various places                                                            |

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -58,7 +58,7 @@ function help() {
     echo "--check-connection                Validate the Airbyte source connection"
     echo "--full-refresh                    Force full_refresh and overwrite mode"
     echo "--state <path>                    Override state file path for incremental sync"
-    echo "--src-output-file <path>          Write source output as a file (handy for debugging)"
+    echo "--src-output-file <path>          Write source output as a file (handy for debugging, requires a destination)"
     echo "--src-catalog-overrides <json>    JSON string of sync mode overrides"
     echo "--src-catalog-file <path>         Source catalog file path"
     echo "--src-catalog-json <json>         Source catalog as a JSON string"
@@ -231,6 +231,9 @@ function validateInput() {
     if [[ -z "$dst_docker_image" ]] && ! ((run_src_only)); then
         err "Airbyte destination Docker image must be set using '--dst <image>'"
     fi
+    if [[ "$output_filepath" != "/dev/null" ]] && ((run_src_only)); then
+        err "'--src-output-file' cannot be used with '--src-only'. Consider using '--raw-messages' when running without a destination then redirecting to a file"
+    fi
 }
 
 function writeSrcConfig() {
@@ -284,10 +287,10 @@ function writeConfig() {
 function redactConfigSecrets() {
     loggable_config="$1"
     config_properties="$(echo "$2" | jq -r '.spec.connectionSpecification.properties')"
-    paths_to_redact=($(jq -c --stream 'if .[0][-1] == "airbyte_secret" and .[1] then .[0] else null end 
-                                       | select(. != null) 
-                                       | .[0:-1] 
-                                       | map(select(. != "properties" and 
+    paths_to_redact=($(jq -c --stream 'if .[0][-1] == "airbyte_secret" and .[1] then .[0] else null end
+                                       | select(. != null)
+                                       | .[0:-1]
+                                       | map(select(. != "properties" and
                                                     . != "oneOf" and
                                                     . != "anyOf" and
                                                     (.|tostring|test("^\\d+$")|not)))' <<< "$config_properties"))


### PR DESCRIPTION
## Description

We can now use `--src-wizard` and `--dst-wizard` to run the configuration wizard (provided the connectors implement it)
```
./airbyte-local.sh  \
--src 'farosai/airbyte-faros-feeds-source'  \
--src-wizard \
--dst 'farosai/airbyte-faros-destination' \
--dst-wizard
```

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
