### PR TITLE
FAI-6758 - Log connector image digests and io.airbyte.version labels

### DIFF
--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -880,7 +880,7 @@ function logImageVersion() {
     if [[ -z ${k8s_deployment+x} ]]; then
         log "$1 image digest is $(docker inspect --format='{{index .RepoDigests 0}}' "$2")"
         local image_label=$(docker inspect --format='{{index .Config.Labels "io.airbyte.version"}}' "$2")
-        log "$1 image version label is ${image_label:-unknown}"
+        log "$1 image version is ${image_label:-unknown}"
     fi
 }
 

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -877,9 +877,11 @@ function err() {
 }
 
 function logImageVersion() {
-    log "$1 image digest is $(docker inspect --format='{{index .RepoDigests 0}}' "$2")"
-    local image_label=$(docker inspect --format='{{index .Config.Labels "io.airbyte.version"}}' "$2")
-    log "$1 image version label is $image_label"
+    if [[ -z ${k8s_deployment+x} ]]; then
+        log "$1 image digest is $(docker inspect --format='{{index .RepoDigests 0}}' "$2")"
+        local image_label=$(docker inspect --format='{{index .Config.Labels "io.airbyte.version"}}' "$2")
+        log "$1 image version label is $image_label"
+    fi
 }
 
 function checkBashVersion() {

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -876,6 +876,12 @@ function err() {
     exit 1
 }
 
+function logImageVersion() {
+    log "$1 image digest is $(docker inspect --format='{{index .RepoDigests 0}}' "$2")"
+    local image_label=$(docker inspect --format='{{index .Config.Labels "io.airbyte.version"}}' "$2")
+    log "$1 image version label is $image_label"
+}
+
 function checkBashVersion() {
     bash_minor_version=$(echo "${BASH_VERSION}" | cut -d '.' -f 2)
     if [ $bash_major_version -eq 4 ] && [ $bash_minor_version -lt 3 ]; then
@@ -908,6 +914,7 @@ main() {
             docker pull $src_docker_image
         fi
     fi
+    logImageVersion "Source" "$src_docker_image"
     writeSrcConfig
     writeSrcCatalog
 
@@ -925,6 +932,7 @@ main() {
                 docker pull $dst_docker_image
             fi
         fi
+        logImageVersion "Destination" "$dst_docker_image"
         parseStreamPrefix
         loadState
         writeDstConfig

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -880,7 +880,7 @@ function logImageVersion() {
     if [[ -z ${k8s_deployment+x} ]]; then
         log "$1 image digest is $(docker inspect --format='{{index .RepoDigests 0}}' "$2")"
         local image_label=$(docker inspect --format='{{index .Config.Labels "io.airbyte.version"}}' "$2")
-        log "$1 image version label is $image_label"
+        log "$1 image version label is ${image_label:-unknown}"
     fi
 }
 


### PR DESCRIPTION
## Description

Airbyte standardizes its community images on the "io.airbyte.version" label, and we follow that standard for our own images. I'm also logging the image digest, so for custom images that may not have that label, we can still pull and inspect the image.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
