### PR TITLE
FAI-7388 Copy Faros API cfg from destination cfg to source cfg + Make writeConfig more robust

### DIFF
--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -319,8 +319,10 @@ function writeSrcConfig() {
 
 function copyFarosConfig() {
     if [[ $src_docker_image == farosai/airbyte-faros-feeds-source* && $dst_docker_image == farosai/airbyte-faros-destination* ]]; then
+            # Extract Faros API config from destination config
             faros_config=$(jq '{faros: {api_url: .edition_configs.api_url, api_key: .edition_configs.api_key, graph: .edition_configs.graph, graphql_api: .edition_configs.graphql_api} | with_entries(if .value==null then empty else . end)}' "$tempdir/$dst_config_filename")
             debug "Updating source config with Faros API config from destination config: $(echo "$faros_config" | jq '.faros.api_key = "REDACTED"')"
+            # Merge Faros API config into source config
             jq --argjson faros_config "$faros_config" '$faros_config + .' "$tempdir/$src_config_filename" > "$tempdir/$src_config_filename.tmp"
             mv "$tempdir/$src_config_filename.tmp" "$tempdir/$src_config_filename"
             debug "Using source config: $(redactConfigSecrets "$(jq -c < $tempdir/$src_config_filename)" "$(specSrc)")"

--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -321,7 +321,7 @@ function copyFarosConfig() {
     if [[ $src_docker_image == farosai/airbyte-faros-feeds-source* && $dst_docker_image == farosai/airbyte-faros-destination* ]]; then
             faros_config=$(jq '{faros: {api_url: .edition_configs.api_url, api_key: .edition_configs.api_key, graph: .edition_configs.graph, graphql_api: .edition_configs.graphql_api} | with_entries(if .value==null then empty else . end)}' "$tempdir/$dst_config_filename")
             debug "Updating source config with Faros API config from destination config: $(echo "$faros_config" | jq '.faros.api_key = "REDACTED"')"
-            jq --argjson faros_config "$faros_config" '. | $faros_config + .' "$tempdir/$src_config_filename" > "$tempdir/$src_config_filename.tmp"
+            jq --argjson faros_config "$faros_config" '$faros_config + .' "$tempdir/$src_config_filename" > "$tempdir/$src_config_filename.tmp"
             mv "$tempdir/$src_config_filename.tmp" "$tempdir/$src_config_filename"
             debug "Using source config: $(redactConfigSecrets "$(jq -c < $tempdir/$src_config_filename)" "$(specSrc)")"
     fi


### PR DESCRIPTION
## Description

Copy Faros API cfg from destination cfg to source cfg.
This is only done when the source is `farosai/airbyte-faros-feeds-source` and the destination is the Faros destination.
In this case, users of the CLI can omit Faros API config arguments from the source args. 

```
./airbyte-local.sh \
  --src farosai/airbyte-faros-feeds-source:latest \
  --src.feed_cfg.feed_name "github-feed" \
  --src.feed_cfg.auth_cfg.auth "token" \
  --src.feed_cfg.auth_cfg.personal_access_token $GH_TOKEN \
  --src.feed_cfg.org_repo_list '["faros-ai/airbyte-connectors"]'  \
  --src.feed_cfg.repos_query_mode.query_mode "FarosGraph" \
  --dst farosai/airbyte-faros-destination:latest \
  --dst.edition_configs.api_key $FAROS_API_KEY \
  --dst.edition_configs.api_url "https://prod.api.faros.ai" \
  --dst.edition_configs.graph "ypc-test" \
  --dst.edition_configs.graphql_api "v2" \
  --debug
```
![Screenshot 2023-09-22 at 10 13 38 AM](https://github.com/faros-ai/airbyte-local-cli/assets/99700024/389bd2e0-7aeb-4e3c-87d5-53848d5e6ca2)
![Screenshot 2023-09-22 at 10 14 24 AM](https://github.com/faros-ai/airbyte-local-cli/assets/99700024/8fcca7f3-d513-4772-8fae-846abe5c8809)

While working on this, I upgraded my `jq` from 1.6 to 1.7 and found out that `split` behaves differently and this broke the `writeConfig` function. In `writeConfig`, we create a long string of the key/value pairs of config items passed via the CLI args, separated by a special separator. We then have a `jq` expression to split by the separator and merge all the key/value pairs to create the json config. This logic assumes that the number of elements after `split` is an even number. But sadly this is no longer true in version 1.7:
![Screenshot 2023-09-22 at 10 23 04 AM](https://github.com/faros-ai/airbyte-local-cli/assets/99700024/b1a7d3c0-62a4-4db3-9a82-ee6cb654ddae)

To make this work in 1.7, we just trim the last occurrence of the separator.

![Screenshot 2023-09-22 at 10 25 03 AM](https://github.com/faros-ai/airbyte-local-cli/assets/99700024/2c139d86-a3f8-42b4-87b0-e56670fd7df9)


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
