### PR TITLE
FAI-8527 - Fix config redaction when one-letter filenames are present

### DIFF
--- a/airbyte-local.sh
+++ b/airbyte-local.sh
@@ -406,9 +406,10 @@ function redactConfigSecrets() {
                                        | map(select(. != "properties" and
                                                     . != "oneOf" and
                                                     . != "anyOf" and
-                                                    (.|tostring|test("^\\d+$")|not)))' <<< "$config_properties"))
+                                                    (.|tostring|test("^\\d+$")|not))) | tostring' <<< "$config_properties"))
     for path in "${paths_to_redact[@]}"; do\
-        loggable_config="$(jq -c --argjson path "$path" 'if getpath($path) != null then setpath($path; "REDACTED") else . end' <<< "$loggable_config")"
+        path_json=$(echo $path | jq -c '.|fromjson')
+        loggable_config="$(jq -c --argjson path "$path_json" 'if getpath($path) != null then setpath($path; "REDACTED") else . end' <<< "$loggable_config")"
     done
     echo "$loggable_config"
 }


### PR DESCRIPTION
## Description

If a file exists whose name is exactly one letter where that letter is in one of the config paths to redact, bash replaces the path string with that letter when assigning the output of this [jq expression](https://github.com/faros-ai/airbyte-local-cli/blob/main/airbyte-local.sh#L400-L409) to an array variable. No idea why it does this.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
