### PR TITLE
Avoid having jq read files directly & fix file line endings 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh text eol=lf


### PR DESCRIPTION
## Description

Avoid having jq read files directly & fix file line endings. This comes to fix issues when running the CLI on Windows and git-bash

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
