### PR TITLE
[FAI-14452] update ci to use shellspec cli

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install ShellSpec
         run: |
-          curl -fsSL https://git.io/shellspec | sh -s 0.28.1
+          curl -fsSL https://git.io/shellspec | sh -s 0.28.1 --yes
     
       # Run shellspec tests againgst airbyte-local nodejs
       - name: Run ShellSpec tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,16 +48,6 @@ jobs:
         working-directory: test
         run: |
           docker build . -t 'farosai/shellspec:kcov'
-    
-      # Run shellspec tests againgst airbyte-local nodejs
-      - name: Run ShellSpec tests
-        working-directory: airbyte-local-cli-nodejs
-        run: |
-          docker run --rm \
-            -v "$PWD/test/exec:/src" \
-            -v "$PWD/test/resources:/src/resources" \
-            -v "$PWD/out/pkg/airbyte-local:/src/airbyte-local" \
-            farosai/shellspec:kcov
 
       # Run shellspec tests againgst airbyte-local.sh
       - name: Run ShellSpec tests
@@ -66,6 +56,18 @@ jobs:
             -v "$PWD/test:/src" \
             -v "$PWD/airbyte-local.sh:/airbyte-local.sh" \
             farosai/shellspec:kcov  
+
+      - name: Install ShellSpec
+        run: |
+          curl -fsSL https://git.io/shellspec | sh -s 0.28.1
+    
+      # Run shellspec tests againgst airbyte-local nodejs
+      - name: Run ShellSpec tests
+        working-directory: airbyte-local-cli-nodejs
+        run: |
+          pkg --output ./test/exec/airbyte-local -t linuxstatic dist/index.js
+          cp -rf ./test/resources ./test/exec/resources
+          shellspec --chdir ./test/exec
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Run ShellSpec tests
         working-directory: airbyte-local-cli-nodejs
         run: |
-          pkg --output ./test/exec/airbyte-local -t linuxstatic dist/index.js
+          cp ./out/pkg/airbyte-local ./test/exec/airbyte-local
           cp -rf ./test/resources ./test/exec/resources
           shellspec --chdir ./test/exec
 


### PR DESCRIPTION
## Description

> Provide description here

use shellspec cli instead of docker in github action.
this should allow us to easier run e2e tests that involving spinning up a docker container.
so that it's not much different of testing locally and running in github action.

I didn't touch the old one. keep the old one still using the shellspec docker.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change