### PR TITLE
[FAI-14970] Skip runnning discover catalog with dst only

### DIFF
--- a/airbyte-local-cli-nodejs/src/docker.ts
+++ b/airbyte-local-cli-nodejs/src/docker.ts
@@ -190,7 +190,7 @@ export async function runDiscoverCatalog(tmpDir: string, image: string | undefin
 
     if (rawCatalog?.type === AirbyteMessageType.CATALOG && res[0].StatusCode === 0) {
       logger.info('Catalog discovered successfully.');
-      return rawCatalog.catalog ?? {};
+      return rawCatalog.catalog ?? {streams: []};
     }
     throw new Error('Catalog not found or container ends with non-zero status code');
   } catch (error: any) {

--- a/airbyte-local-cli-nodejs/src/types.ts
+++ b/airbyte-local-cli-nodejs/src/types.ts
@@ -41,7 +41,7 @@ export interface CliOptions {
 export interface AirbyteConfig {
   image: string;
   config?: object;
-  catalog?: object;
+  catalog?: AirbyteConfiguredCatalog;
   dockerOptions?: AirbyteConfigDockerOptions;
 }
 export interface AirbyteConfigDockerOptions {
@@ -116,7 +116,7 @@ export enum DestinationSyncMode {
 }
 export interface AirbyteStream {
   name: string;
-  json_schema: Dictionary<any>;
+  json_schema?: Dictionary<any>;
   supported_sync_modes?: SyncMode[];
   source_defined_cursor?: boolean;
   default_cursor_field?: string[];

--- a/airbyte-local-cli-nodejs/test/exec/spec/index_spec.sh
+++ b/airbyte-local-cli-nodejs/test/exec/spec/index_spec.sh
@@ -134,6 +134,26 @@ Describe 'Run source sync'
   End
 End
 
+Describe 'Run destination sync'
+  It 'should succeed with dstOnly'
+    airbyte_local_test() {
+
+      jq --arg api_key "$FAROS_API_KEY" '
+        .dst.config.edition_configs.api_key = $api_key
+      ' ./resources/test_config_file_dst_only.json.template > ./resources/test_config_file_dst_only.json
+
+      ./airbyte-local \
+        --config-file './resources/test_config_file_dst_only.json' \
+        --dst-only './resources/dockerIt_runDstSync/faros_airbyte_cli_src_output'
+    }
+    When call airbyte_local_test
+    The output should include '[DST] - {"log":{"level":"INFO","message":"Errored 0 records"},"type":"LOG"}'
+    The output should include "Destination connector ran successfully."
+    The output should include "Airbyte CLI completed successfully."
+    The status should equal 0
+  End
+End
+
 Describe 'Run source and destination sync'
   It 'should succeed with src and dst'
     airbyte_local_test() {
@@ -147,11 +167,11 @@ Describe 'Run source and destination sync'
         --config-file './resources/test_config_file_graph_copy.json'
     }
     When call airbyte_local_test
-    The status should equal 0
     The output should include "Source connector ran successfully."
     The output should include '[DST] - {"log":{"level":"INFO","message":"Errored 0 records"},"type":"LOG"}'
     The output should include "Destination connector ran successfully."
     The output should include "Airbyte CLI completed successfully."
+    The status should equal 0
   End
 End
 
@@ -160,6 +180,7 @@ cleanup() {
   find . -name 'faros_airbyte_cli_config.json' -delete
   find . -name '*_cid' -delete
   find . -name '*state.json' -delete
+  find ./resources/ -name 'test_config_file_dst_only.json' -delete
   find ./resources/ -name 'test_config_file_graph_copy.json' -delete
 }
 AfterAll 'cleanup'

--- a/airbyte-local-cli-nodejs/test/resources/test_config_file_dst_only.json.template
+++ b/airbyte-local-cli-nodejs/test/resources/test_config_file_dst_only.json.template
@@ -1,0 +1,25 @@
+{
+  "dst": {
+    "image": "farosai/airbyte-faros-destination",
+    "config": {
+      "edition_configs": {
+        "edition": "cloud",
+        "graph": "jennie-test",
+        "graphql_api": "v2",
+        "api_url": "https://dev.api.faros.ai",
+        "api_key": ""
+      }
+    },
+    "catalog": {
+      "streams":[
+         {
+            "stream":{
+               "name":"myfarosgraphqlsrc__faros_graphql__faros_graph"
+            },
+            "sync_mode":"incremental",
+            "destination_sync_mode":"append"
+         }
+      ]
+   }
+  }
+}


### PR DESCRIPTION
## Description

> Provide description here

Users are not required to provide source config when it's dst only.
but they will be obligated to provide the corresponding catalog and dst stream with the correct prefix.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change