### PR TITLE
Fix github action sonar scan version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           shellspec --chdir ./test/exec
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@v5
+        uses: SonarSource/sonarqube-scan-action@v4.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           shellspec --chdir ./test/exec
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           shellspec --chdir ./test/exec
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4.2.0
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           shellspec --chdir ./test/exec
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@v4
+        uses: sonarsource/sonarcloud-github-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Description

> Provide description here

trying to fix this.

```
Download action repository 'sonarsource/sonarcloud-github-action@master' (SHA:f1700773ebdb6efe6b3f8a5cf66150027dda8f5e)
Getting action download info
Download action repository 'SonarSource/sonarqube-scan-action@v4.1.0' (SHA:1b442ee39ac3fa7c2acdd[41](https://github.com/faros-ai/airbyte-local-cli/actions/runs/13396689760/job/37420016350#step:1:47)0208dcb2bcfaae6c4)
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v4.0.2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```

https://community.sonarsource.com/t/github-action-v4-x-x-started-getting-an-unable-to-resolve-action-on-cache-version-4-0-2/131962/3

ok `sonarcloud-github-action` is deprecated. switch to use scan
https://github.com/SonarSource/sonarcloud-github-action/releases