### PR TITLE
[FAI-16250] Allow users to pass in additional docker volume mount

### DIFF
--- a/airbyte-local-cli-nodejs/package-lock.json
+++ b/airbyte-local-cli-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@faros-ai/airbyte-local-cli-nodejs",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",

--- a/airbyte-local-cli-nodejs/package.json
+++ b/airbyte-local-cli-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Airbyte local cli node js version",
   "private": true,
   "packageManager": "^npm@10.8.2",

--- a/airbyte-local-cli-nodejs/src/version.ts
+++ b/airbyte-local-cli-nodejs/src/version.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '0.0.5';
+export const CLI_VERSION = '0.0.6';

--- a/airbyte-local-cli-nodejs/test/__snapshots__/utils.it.test.ts.snap
+++ b/airbyte-local-cli-nodejs/test/__snapshots__/utils.it.test.ts.snap
@@ -93,6 +93,13 @@ exports[`parseConfigFile should parse utf16 encoding 1`] = `
       "username": "test-username",
     },
     "dockerOptions": {
+      "additionalOptions": {
+        "HostConfig": {
+          "Binds": [
+            "/test/path:/test/path/test.json",
+          ],
+        },
+      },
       "maxCpus": 2,
       "maxMemory": 2048,
     },
@@ -127,6 +134,13 @@ exports[`parseConfigFile should pass 1`] = `
       "username": "test-username",
     },
     "dockerOptions": {
+      "additionalOptions": {
+        "HostConfig": {
+          "Binds": [
+            "/test/path:/test/path/test.json",
+          ],
+        },
+      },
       "maxCpus": 2,
       "maxMemory": 2048,
     },

--- a/airbyte-local-cli-nodejs/test/docker.test.ts
+++ b/airbyte-local-cli-nodejs/test/docker.test.ts
@@ -1,0 +1,55 @@
+import * as docker from '../src/docker';
+import {FarosConfig} from '../src/types';
+
+describe('runSrcSync', () => {
+  const testCfg: FarosConfig = {
+    src: {
+      image: 'farosai/airbyte-example-source',
+    },
+    srcCheckConnection: false,
+    dstUseHostNetwork: false,
+    srcPull: false,
+    dstPull: false,
+    fullRefresh: false,
+    rawMessages: false,
+    keepContainers: false,
+    logLevel: 'info',
+    debug: false,
+    stateFile: undefined,
+    connectionName: undefined,
+    srcOutputFile: undefined,
+    srcInputFile: undefined,
+    silent: false,
+    image: false,
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call runDocker with correct parameters', async () => {
+    const mockRunDocker = jest.spyOn(docker, 'runDocker').mockResolvedValue(undefined);
+
+    const testCfgWithVolumeMount = {
+      ...testCfg,
+      src: {
+        ...testCfg.src,
+        dockerOptions: {
+          additionalOptions: {
+            HostConfig: {
+              Binds: ['/path/to/tasks.xlsx:/tasks.xlsx'],
+            },
+          },
+        },
+      },
+    } as FarosConfig;
+
+    await docker.runSrcSync('testTmpDir', testCfgWithVolumeMount, process.stdout);
+
+    expect(mockRunDocker).toHaveBeenCalled();
+    expect(mockRunDocker.mock.calls[0]?.[0]?.HostConfig?.Binds).toMatchObject([
+      'testTmpDir:/configs',
+      '/path/to/tasks.xlsx:/tasks.xlsx',
+    ]);
+  });
+});

--- a/airbyte-local-cli-nodejs/test/resources/test_config_file.json
+++ b/airbyte-local-cli-nodejs/test/resources/test_config_file.json
@@ -9,7 +9,14 @@
     "catalog": {},
     "dockerOptions": {
       "maxMemory": 2048,
-      "maxCpus": 2
+      "maxCpus": 2,
+      "additionalOptions": {
+        "HostConfig": {
+          "Binds": [
+            "/test/path:/test/path/test.json"
+          ]
+        }
+      }
     }
   },
   "dst": {


### PR DESCRIPTION
## Description

> Provide description here

It looks like we need this for import sheets 
https://docs.faros.ai/docs/importing-org-data-from-a-local-spreadsheet#/

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
