### PR TITLE
Add unit test for crlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 
 *.sh text eol=lf
+**test_config_file_crlf.json text eol=crlf # for testing

--- a/airbyte-local-cli-nodejs/test/__snapshots__/utils.it.test.ts.snap
+++ b/airbyte-local-cli-nodejs/test/__snapshots__/utils.it.test.ts.snap
@@ -67,7 +67,7 @@ exports[`generateConfig should succeed with static configs 1`] = `
 "
 `;
 
-exports[`parseConfigFile should parse utf16 encoding 1`] = `
+exports[`parseConfigFile should parse crlf 1`] = `
 {
   "dst": {
     "catalog": {},
@@ -100,6 +100,40 @@ exports[`parseConfigFile should parse utf16 encoding 1`] = `
           ],
         },
       },
+      "maxCpus": 2,
+      "maxMemory": 2048,
+    },
+    "image": "farosai/airbyte-servicenow-source",
+  },
+}
+`;
+
+exports[`parseConfigFile should parse utf16 encoding 1`] = `
+{
+  "dst": {
+    "catalog": {},
+    "config": {
+      "edition_config": {
+        "api_key": "***",
+        "api_url": "https://prod.api.faros.ai",
+        "edition": "cloud",
+        "graph": "default",
+      },
+    },
+    "dockerOptions": {
+      "maxCpus": 2,
+      "maxMemory": 2048,
+    },
+    "image": "farosai/airbyte-servicenow-destination",
+  },
+  "src": {
+    "catalog": {},
+    "config": {
+      "password": "***",
+      "url": "https://test-instance.service-now.com",
+      "username": "test-username",
+    },
+    "dockerOptions": {
       "maxCpus": 2,
       "maxMemory": 2048,
     },

--- a/airbyte-local-cli-nodejs/test/resources/test_config_file_crlf.json
+++ b/airbyte-local-cli-nodejs/test/resources/test_config_file_crlf.json
@@ -1,0 +1,38 @@
+{
+  "src": {
+    "image": "farosai/airbyte-servicenow-source",
+    "config": {
+      "username": "test-username",
+      "password": "***",
+      "url": "https://test-instance.service-now.com"
+    },
+    "catalog": {},
+    "dockerOptions": {
+      "maxMemory": 2048,
+      "maxCpus": 2,
+      "additionalOptions": {
+        "HostConfig": {
+          "Binds": [
+            "/test/path:/test/path/test.json"
+          ]
+        }
+      }
+    }
+  },
+  "dst": {
+    "image": "farosai/airbyte-servicenow-destination",
+    "config": {
+      "edition_config": {
+        "graph": "default",
+        "edition": "cloud",
+        "api_url": "https://prod.api.faros.ai",
+        "api_key": "***"
+      }
+    },
+    "catalog": {},
+    "dockerOptions": {
+      "maxMemory": 2048,
+      "maxCpus": 2
+    }
+  }
+}

--- a/airbyte-local-cli-nodejs/test/utils.it.test.ts
+++ b/airbyte-local-cli-nodejs/test/utils.it.test.ts
@@ -77,7 +77,10 @@ describe('parseConfigFile', () => {
     expect(() => parseConfigFile('test_config_file_invalid')).toThrow();
   });
   it('should parse utf16 encoding', () => {
-    expect(parseConfigFile('test/resources/test_config_file.json')).toMatchSnapshot();
+    expect(parseConfigFile('test/resources/test_config_file_utf16.json')).toMatchSnapshot();
+  });
+  it('should parse crlf', () => {
+    expect(parseConfigFile('test/resources/test_config_file_crlf.json')).toMatchSnapshot();
   });
 });
 


### PR DESCRIPTION
## Description

> Provide description here

This pull request introduces support for parsing configuration files with CRLF line endings, adds a new test configuration file for CRLF, and updates related test cases and snapshots to ensure proper functionality. The changes primarily focus on enhancing the testing framework to handle different file encodings and line endings.

### Enhancements to configuration file parsing:

* Added a new test configuration file `test_config_file_crlf.json` with CRLF line endings to the repository for testing purposes
* Updated the `parseConfigFile` test suite to include a new test case for parsing CRLF-encoded files (`airbyte-local-cli-nodejs/test/utils.it.test.ts`).
