### PR TITLE
[FAI-16849] only recreate latest tag if there's a new version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,7 +205,7 @@ jobs:
 
       # Only recreate the latest tag if a new tag was created
       - name: Recreate latest tag
-        if: steps.create-tag.outputs.tag != null
+        if: ${{ steps.create-tag.outputs.tag != null }}
         run: |
           git push --delete origin latest || true
           git tag -f latest


### PR DESCRIPTION
This pull request updates the CI workflow in `.github/workflows/ci.yaml` to improve the handling of the "latest" tag during the tagging process. The most important change ensures that the "latest" tag is only recreated if a new tag has been created.

Improvements to CI workflow:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR206-R208): Added a conditional (`if: steps.create-tag.outputs.tag != null`) to the "Recreate latest tag" step to ensure that the "latest" tag is only recreated when a new tag has been created.