### PR TITLE
[FAI-17537] Add new source cursor

### DIFF
--- a/airbyte-local-cli-nodejs/package-lock.json
+++ b/airbyte-local-cli-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@faros-ai/airbyte-local-cli-nodejs",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",

--- a/airbyte-local-cli-nodejs/package.json
+++ b/airbyte-local-cli-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Airbyte local cli node js version",
   "private": true,
   "packageManager": "^npm@10.8.2",

--- a/airbyte-local-cli-nodejs/src/constants/airbyteTypes.ts
+++ b/airbyte-local-cli-nodejs/src/constants/airbyteTypes.ts
@@ -161,6 +161,9 @@ export const airbyteTypes: AirbyteTypes = {
     bigquery: {
       dockerRepo: 'airbyte/source-bigquery',
     },
+    cursor: {
+      dockerRepo: 'farosai/airbyte-cursor-source',
+    },
 
     // Feeds sources
     changeset: {

--- a/airbyte-local-cli-nodejs/src/version.ts
+++ b/airbyte-local-cli-nodejs/src/version.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '0.0.9';
+export const CLI_VERSION = '0.0.10';


### PR DESCRIPTION
This pull request includes updates to the version of the `@faros-ai/airbyte-local-cli-nodejs` package and adds a new Airbyte source type. The most important changes include the version bump to `0.0.10`, the addition of the `cursor` Airbyte source, and the corresponding updates to version-related constants and metadata files.

### Version updates:
* Updated the `version` field in `package.json` and `package-lock.json` to `0.0.10`, reflecting the new release version. (`[[1]](diffhunk://#diff-dd1fdd4ed8d30e34f5430be5f8169d15bcf36c6b45f4ca89a2e3f645a148add9L3-R3)`, `[[2]](diffhunk://#diff-eda83e8c4f8f7ba146ee529af4db344b8e640cd31ffab00b37fa3e1a1e57ce95L3-R9)`)
* Updated the `CLI_VERSION` constant in `src/version.ts` to `0.0.10`. (`[airbyte-local-cli-nodejs/src/version.tsL1-R1](diffhunk://#diff-2e15914795a909ef072612be1c377af1e5a2f61a530489ca0a5a0cc5df329d1fL1-R1)`)

### New Airbyte source:
* Added a new Airbyte source type, `cursor`, with its `dockerRepo` set to `farosai/airbyte-cursor-source` in `src/constants/airbyteTypes.ts`. (`[airbyte-local-cli-nodejs/src/constants/airbyteTypes.tsR164-R166](diffhunk://#diff-629560355343f3d22e5fdd3881c125872a8c925448d39db94ac5a7896584e9bfR164-R166)`)