### PR TITLE
Add dst stream prefix flag

### DIFF
--- a/airbyte-local-cli-nodejs/package-lock.json
+++ b/airbyte-local-cli-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@faros-ai/airbyte-local-cli-nodejs",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",

--- a/airbyte-local-cli-nodejs/package.json
+++ b/airbyte-local-cli-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Airbyte local cli node js version",
   "private": true,
   "packageManager": "^npm@10.8.2",

--- a/airbyte-local-cli-nodejs/src/command.ts
+++ b/airbyte-local-cli-nodejs/src/command.ts
@@ -73,6 +73,13 @@ function command() {
     .addOption(new Option('--check-connection', 'Support for the renamed option').hideHelp())
     .addOption(new Option('--state <file>', 'Support for the renamed option').hideHelp())
 
+    // Options: hidden options
+    .addOption(
+      new Option('--dst-stream-prefix <prefix>', 'Override destination stream prefix')
+        .hideHelp()
+        .conflicts('connectionName'),
+    )
+
     // Additional check
     .action((opts: any) => {
       if (opts.debug) {
@@ -273,6 +280,7 @@ export function parseAndValidateInputs(argv: string[]): FarosConfig {
     keepContainers: cliOptions.keepContainers ?? false,
     logLevel: cliOptions.logLevel ?? 'info',
     debug: cliOptions.debug ?? false,
+    dstStreamPrefix: cliOptions.dstStreamPrefix,
   };
 
   if (cliOptions.srcImage || cliOptions.dstImage) {

--- a/airbyte-local-cli-nodejs/src/types.ts
+++ b/airbyte-local-cli-nodejs/src/types.ts
@@ -24,6 +24,7 @@ export interface CliOptions {
   dstUseHostNetwork?: boolean;
   dstOnly?: string;
   dstPull?: boolean;
+  dstStreamPrefix?: string;
 
   // general connector settings
   connectionName?: string;
@@ -76,6 +77,7 @@ export interface FarosConfig {
   dstPull: boolean;
   connectionName: string | undefined;
   stateFile: string | undefined;
+  dstStreamPrefix?: string | undefined;
   fullRefresh: boolean;
   rawMessages: boolean;
   keepContainers: boolean;
@@ -86,9 +88,6 @@ export interface FarosConfig {
   generateConfig?: any;
   silent: boolean;
   image: boolean;
-
-  // internal use
-  dstStreamPrefix?: string;
 }
 
 export enum OutputStream {

--- a/airbyte-local-cli-nodejs/src/utils.ts
+++ b/airbyte-local-cli-nodejs/src/utils.ts
@@ -465,9 +465,15 @@ export async function processSrcInputFile(tmpDir: string, cfg: FarosConfig): Pro
  * Only update if the destination image is a Faros destination image.
  */
 export function generateDstStreamPrefix(cfg: FarosConfig): void {
+  // If dstStreamPrefix is already set via CLI flag, skip generation
+  if (cfg.dstStreamPrefix) {
+    logger.info(`Using provided destination stream prefix: ${cfg.dstStreamPrefix}`);
+    return;
+  }
+
   const srcImage = cfg.src?.image;
   const dstImage = cfg.dst?.image;
-  if (dstImage?.startsWith('farosai/airbyte-faros-destination')) {
+  if (dstImage?.startsWith('farosai/')) {
     // if source image is a faros feed image
     if (
       !cfg.connectionName &&

--- a/airbyte-local-cli-nodejs/src/version.ts
+++ b/airbyte-local-cli-nodejs/src/version.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '0.0.10';
+export const CLI_VERSION = '0.0.11';

--- a/airbyte-local-cli-nodejs/test/utils.test.ts
+++ b/airbyte-local-cli-nodejs/test/utils.test.ts
@@ -269,4 +269,15 @@ describe('generateDstStreamPrefix', () => {
     expect(testAirbyteConfig.connectionName).toEqual('testConnectionName');
     expect(testAirbyteConfig.dstStreamPrefix).toEqual('testConnectionName__faros_feeds__');
   });
+
+  it('should skip generation when dstStreamPrefix is provided via CLI flag', () => {
+    const testAirbyteConfig = {
+      src: {image: 'farosai/airbyte-example-source:latest'},
+      dst: {image: 'farosai/airbyte-faros-destination:latest'},
+      dstStreamPrefix: 'custom_prefix__',
+    } as FarosConfig;
+    generateDstStreamPrefix(testAirbyteConfig);
+    expect(testAirbyteConfig.dstStreamPrefix).toEqual('custom_prefix__');
+    expect(testAirbyteConfig.connectionName).toBeUndefined();
+  });
 });


### PR DESCRIPTION
This pull request introduces support for overriding the destination stream prefix via a new CLI option, improves internal handling of the stream prefix, and updates relevant types and tests to accommodate this new functionality. The changes ensure that if a user provides a destination stream prefix using the CLI flag, it is respected and not overwritten by automatic generation logic.

**CLI Option and Input Handling:**

* Added a new hidden CLI option `--dst-stream-prefix <prefix>` to allow users to override the destination stream prefix, with conflict handling for the `connectionName` option.
* Updated the input parsing logic in `parseAndValidateInputs` to include the new `dstStreamPrefix` option in the configuration.

**Type Updates:**

* Added `dstStreamPrefix` to both `CliOptions` and `FarosConfig` interfaces, ensuring consistent type support for the new option. [[1]](diffhunk://#diff-2c1d9117c47db9743970431d8219365db0686b5fdce39f410677db977ead13e5R27) [[2]](diffhunk://#diff-2c1d9117c47db9743970431d8219365db0686b5fdce39f410677db977ead13e5R80)
* Removed the internal-only comment for `dstStreamPrefix` in `FarosConfig` to clarify its usage.

**Stream Prefix Generation Logic:**

* Modified `generateDstStreamPrefix` to skip automatic prefix generation if `dstStreamPrefix` is set via the CLI, logging the usage of the provided value. Also broadened the destination image check to any `farosai/` image.

**Testing:**

* Added a test to verify that prefix generation is skipped when `dstStreamPrefix` is provided via the CLI, ensuring correct behavior.

<img width="1512" height="774" alt="Screenshot 2025-08-06 at 15 59 26" src="https://github.com/user-attachments/assets/ce43e71b-0e1b-4290-a278-f49989d5699e" />

