### PR TITLE
Update log image version to not fail on missing docker labels

### DIFF
--- a/airbyte-local-cli-nodejs/package-lock.json
+++ b/airbyte-local-cli-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@faros-ai/airbyte-local-cli-nodejs",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",

--- a/airbyte-local-cli-nodejs/package.json
+++ b/airbyte-local-cli-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Airbyte local cli node js version",
   "private": true,
   "packageManager": "^npm@10.8.2",

--- a/airbyte-local-cli-nodejs/src/docker.ts
+++ b/airbyte-local-cli-nodejs/src/docker.ts
@@ -91,7 +91,7 @@ export async function pullDockerImage(image: string): Promise<void> {
   }
 }
 
-export async function inspectDockerImage(image: string): Promise<{digest: string; version: string}> {
+export async function inspectDockerImage(image: string): Promise<{digest?: string; version?: string}> {
   logger.debug(`Inspecting docker image: ${image}`);
 
   try {
@@ -106,8 +106,8 @@ export async function inspectDockerImage(image: string): Promise<{digest: string
     }
     return {digest, version};
   } catch (error: any) {
-    logger.error(`Failed to inspect docker image: ${image}`);
-    throw error;
+    logger.warn(`Failed to inspect docker image '${image}': ${error.message ?? JSON.stringify(error)}`);
+    return {};
   }
 }
 

--- a/airbyte-local-cli-nodejs/src/utils.ts
+++ b/airbyte-local-cli-nodejs/src/utils.ts
@@ -57,8 +57,12 @@ export async function logImageVersion(type: ImageType, image: string | undefined
     return;
   }
   const {digest, version} = await inspectDockerImage(image);
-  logger.info(`Using ${type} image digest ${digest}`);
-  logger.info(`Using ${type} image version ${version}`);
+  if (digest && version) {
+    logger.info(`Using ${type} image digest ${digest}`);
+    logger.info(`Using ${type} image version ${version}`);
+  } else {
+    logger.warn(`Unknown ${type} image version or digest`);
+  }
 }
 
 // Read a file and detect the encoding by checking Byte Order Mark

--- a/airbyte-local-cli-nodejs/src/version.ts
+++ b/airbyte-local-cli-nodejs/src/version.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '0.0.11';
+export const CLI_VERSION = '0.0.12';

--- a/airbyte-local-cli-nodejs/test/resources/test_config_file_src_only.json
+++ b/airbyte-local-cli-nodejs/test/resources/test_config_file_src_only.json
@@ -1,6 +1,6 @@
 {
   "src": {
-    "image": "gerrit",
+    "image": "farosai/airbyte-example-source",
     "config": {
       "user": "chris"
     }

--- a/airbyte-local-cli-nodejs/test/resources/test_config_file_src_only.json
+++ b/airbyte-local-cli-nodejs/test/resources/test_config_file_src_only.json
@@ -1,6 +1,6 @@
 {
   "src": {
-    "image": "farosai/airbyte-example-source",
+    "image": "gerrit",
     "config": {
       "user": "chris"
     }


### PR DESCRIPTION
This pull request updates the Docker image inspection and logging logic to be more robust against errors, and modifies a test resource configuration. The main improvements are better error handling when inspecting Docker images, safer logging of image details, and a test update to use a different image.

**Docker image inspection and error handling:**

* The `inspectDockerImage` function now returns an object with optional `digest` and `version` fields instead of always requiring them, allowing for cases where inspection fails.
* If inspecting a Docker image fails, the function logs a warning with the error message and returns an empty object, instead of throwing an error.

**Image version logging:**

* The `logImageVersion` function now checks for both `digest` and `version` before logging; if either is missing, it logs a warning instead of info.

**Test configuration update:**

* The test configuration file `test_config_file_src_only.json` now uses the `gerrit` image instead of `farosai/airbyte-example-source`.