### PR TITLE
Add min-release-age for supply chain security (nodejs CLI)

### DIFF
--- a/airbyte-local-cli-nodejs/.npmrc
+++ b/airbyte-local-cli-nodejs/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/airbyte-local-cli-nodejs/package.json
+++ b/airbyte-local-cli-nodejs/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Airbyte local cli node js version",
   "private": true,
-  "packageManager": "^npm@10.8.2",
+  "packageManager": "^npm@11.10.0",
   "scripts": {
     "version": "node -p \"'export const CLI_VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",
     "bump-beta": "npm version prerelease --preid=beta ",
@@ -28,7 +28,8 @@
     "url": "https://github.com/faros-ai/airbyte-local-cli/issues"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.0.0",
+    "npm": ">=11.10.0"
   },
   "main": "lib/",
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds supply chain security protections to the Node.js CLI to restrict dependency resolution to packages published at least 7 days ago using npm 11's `min-release-age` feature.

### Changes (in `airbyte-local-cli-nodejs/`)
- Create `.npmrc` with `min-release-age=7`
- Bump `packageManager` from `^npm@10.8.2` to `^npm@11.10.0` (min-release-age was introduced in 11.10.0)
- Add `engines.npm: ">=11.10.0"`

No CI changes needed — already using Node 24.x which bundles npm 11.

## Test plan

- [ ] Verify CI passes
- [ ] Verify `min-release-age` is enforced during `npm ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)