### PR TITLE
[FAI-21566] Handle docker user mapping to resolve temp dir access issue

### DIFF
--- a/airbyte-local-cli-nodejs/package-lock.json
+++ b/airbyte-local-cli-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@faros-ai/airbyte-local-cli-nodejs",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",

--- a/airbyte-local-cli-nodejs/package.json
+++ b/airbyte-local-cli-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faros-ai/airbyte-local-cli-nodejs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Airbyte local cli node js version",
   "private": true,
   "packageManager": "^npm@11.10.0",

--- a/airbyte-local-cli-nodejs/src/docker.ts
+++ b/airbyte-local-cli-nodejs/src/docker.ts
@@ -42,6 +42,16 @@ import {
 // Constants
 const DEFAULT_MAX_LOG_SIZE = '10m';
 
+/**
+ * On Unix, run containers as the current user so the bind-mounted tmpDir (mode 0700,
+ * owned by the CLI process user) remains accessible without widening its permissions.
+ * process.getuid is not available on Windows.
+ */
+function getContainerUser(): string | undefined {
+  const uid = process.getuid?.();
+  return uid !== undefined ? `${uid}:${process.getgid!()}` : undefined;
+}
+
 // Create a new Docker instance
 let _docker = new Docker();
 
@@ -305,6 +315,7 @@ export async function runCheckSrcConnection(tmpDir: string, image: string, srcCo
       Cmd: command,
       AttachStderr: true,
       AttachStdout: true,
+      User: getContainerUser(),
       HostConfig: {
         Binds: [`${tmpDir}:${getBindsLocation(image)}`],
         AutoRemove: true,
@@ -365,6 +376,7 @@ export async function runDiscoverCatalog(tmpDir: string, image: string | undefin
       Cmd: command,
       AttachStderr: true,
       AttachStdout: true,
+      User: getContainerUser(),
       HostConfig: {
         Binds: [`${tmpDir}:${getBindsLocation(image)}`],
         AutoRemove: true,
@@ -448,6 +460,7 @@ export async function runSrcSync(tmpDir: string, config: FarosConfig, srcOutputS
       // Default config: can be overridden by the docker options provided by users
       name: srcContainerName,
       Image: config.src.image,
+      User: getContainerUser(),
       ...config.src?.dockerOptions?.additionalOptions,
 
       // Default options: cannot be overridden by users
@@ -577,6 +590,7 @@ export async function runDstSync(tmpDir: string, config: FarosConfig, srcPassThr
       // Default config: can be overridden by the docker options provided by users
       name: dstContainerName,
       Image: config.dst.image,
+      User: getContainerUser(),
       ...config.dst?.dockerOptions?.additionalOptions,
 
       // Default options: cannot be overridden by users
@@ -739,6 +753,7 @@ export async function runWizard(tmpDir: string, image: string, spec: AirbyteSpec
       Cmd: cmd,
       AttachStderr: true,
       AttachStdout: true,
+      User: getContainerUser(),
       HostConfig: {
         Binds: [`${tmpDir}:${getBindsLocation(image)}`],
         AutoRemove: true,

--- a/airbyte-local-cli-nodejs/src/docker.ts
+++ b/airbyte-local-cli-nodejs/src/docker.ts
@@ -49,7 +49,8 @@ const DEFAULT_MAX_LOG_SIZE = '10m';
  */
 function getContainerUser(): string | undefined {
   const uid = process.getuid?.();
-  return uid !== undefined ? `${uid}:${process.getgid!()}` : undefined;
+  const gid = process.getgid?.();
+  return uid !== undefined && gid !== undefined ? `${uid}:${gid}` : undefined;
 }
 
 // Create a new Docker instance

--- a/airbyte-local-cli-nodejs/src/utils.ts
+++ b/airbyte-local-cli-nodejs/src/utils.ts
@@ -1,6 +1,7 @@
 import {spawnSync} from 'node:child_process';
 import {
   accessSync,
+  chmodSync,
   constants,
   createReadStream,
   createWriteStream,
@@ -277,6 +278,9 @@ export function createTmpDir(absTmpDir?: string): string {
   try {
     logger.debug(`Creating temporary directory for temporary Airbyte files...`);
     const tmpDirPath = mkdtempSync(absTmpDir ?? `${tmpdir()}${sep}`);
+    // mkdtempSync creates with mode 0700; widen to 0755 so Docker containers
+    // running as a non-root user (e.g. node/UID 1000) can read bind-mounted files.
+    chmodSync(tmpDirPath, 0o755);
     logger.debug(`Temporary directory created: ${tmpDirPath}.`);
     return tmpDirPath;
   } catch (error: any) {

--- a/airbyte-local-cli-nodejs/src/utils.ts
+++ b/airbyte-local-cli-nodejs/src/utils.ts
@@ -1,7 +1,6 @@
 import {spawnSync} from 'node:child_process';
 import {
   accessSync,
-  chmodSync,
   constants,
   createReadStream,
   createWriteStream,
@@ -278,9 +277,6 @@ export function createTmpDir(absTmpDir?: string): string {
   try {
     logger.debug(`Creating temporary directory for temporary Airbyte files...`);
     const tmpDirPath = mkdtempSync(absTmpDir ?? `${tmpdir()}${sep}`);
-    // mkdtempSync creates with mode 0700; widen to 0755 so Docker containers
-    // running as a non-root user (e.g. node/UID 1000) can read bind-mounted files.
-    chmodSync(tmpDirPath, 0o755);
     logger.debug(`Temporary directory created: ${tmpDirPath}.`);
     return tmpDirPath;
   } catch (error: any) {

--- a/airbyte-local-cli-nodejs/src/version.ts
+++ b/airbyte-local-cli-nodejs/src/version.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '0.2.1';
+export const CLI_VERSION = '0.2.2';

--- a/airbyte-local-cli-nodejs/test/__snapshots__/docker.it.test.ts.snap
+++ b/airbyte-local-cli-nodejs/test/__snapshots__/docker.it.test.ts.snap
@@ -323,6 +323,13 @@ exports[`runSpec should success with faros image 1`] = `
           "title": "Debug",
           "type": "boolean",
         },
+        "describe_connection": {
+          "default": false,
+          "description": "Include connector-specific metadata (e.g., visible orgs, scopes) in the check command output. Only used during CHECK, not during syncs.",
+          "order": 1003,
+          "title": "Describe Connection",
+          "type": "boolean",
+        },
         "faros_source_id": {
           "description": "The ID of the source (aka account)",
           "order": 1001,
@@ -345,12 +352,28 @@ exports[`runSpec should success with faros image 1`] = `
           "title": "Models filter",
           "type": "array",
         },
+        "origins_filter": {
+          "description": "Only fetch records whose origin matches one of these values. Adds an 'origin: {_in: $origins}' clause to the top-level model's where filter on each query.",
+          "items": {
+            "type": "string",
+          },
+          "order": 8,
+          "title": "Origins filter",
+          "type": "array",
+        },
         "page_size": {
           "default": 1000,
           "description": "Page size to use when paginating through query results.",
           "order": 6,
           "title": "Page Size",
           "type": "integer",
+        },
+        "probe_streams": {
+          "default": false,
+          "description": "Include per-stream access checks in the check command output. Only used during CHECK, not during syncs.",
+          "order": 1004,
+          "title": "Probe Streams",
+          "type": "boolean",
         },
         "query": {
           "description": "The query to execute.",
@@ -377,7 +400,7 @@ exports[`runSpec should success with faros image 1`] = `
             "{"faros_board_issues": 24, "faros_users": 48}",
           ],
           "multiline": true,
-          "order": 1003,
+          "order": 1005,
           "title": "Stream Freshness Hours",
           "type": "string",
         },
@@ -397,22 +420,22 @@ exports[`runSpec should success with faros image 1`] = `
 
 exports[`runSrcSync should success 1`] = `
 "{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6uuBQBDv6ajAgAAAA=="}},"type":"STATE","redactedConfig":{"user":"chris"},"sourceType":"example","sourceVersion":***}
-{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uji8uSSxJVbKqrq0FAFiOMFAfAAAA"}},"type":"STATE","sourceStatus":{"status":"SUCCESS"}}
-{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uji8uSSxJVbKqrq0FAFiOMFAfAAAA"}},"type":"STATE","logs":[{"timestamp":***,"message":{"level":30,"msg":"Source version: ***"}},{"timestamp":***,"message":{"level":30,"msg":"Config: {\\"user\\":\\"chris\\"}"}},{"timestamp":***,"message":{"level":30,"msg":"Catalog: {}"}},{"timestamp":***,"message":{"level":30,"msg":"State: {}"}},{"timestamp":***,"message":{"level":30,"msg":"Performing pre-read connection validation"}},{"timestamp":***,"message":{"level":30,"msg":"Pre-read connection validation succeeded"}},{"timestamp":***,"message":{"level":30,"msg":"Syncing ExampleSource"}},{"timestamp":***,"message":{"level":30,"msg":"Finished syncing ExampleSource"}}]}
+{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uBgoklqQqWVXX1gIAWI4wUB8AAAA="}},"type":"STATE","sourceStatus":{"status":"SUCCESS"}}
+{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uBgoklqQqWVXX1gIAWI4wUB8AAAA="}},"type":"STATE","logs":[{"timestamp":***,"message":{"level":30,"msg":"Source version: ***"}},{"timestamp":***,"message":{"level":30,"msg":"Config: {\\"user\\":\\"chris\\"}"}},{"timestamp":***,"message":{"level":30,"msg":"Catalog: {}"}},{"timestamp":***,"message":{"level":30,"msg":"State: {}"}},{"timestamp":***,"message":{"level":30,"msg":"Performing pre-read connection validation"}},{"timestamp":***,"message":{"level":30,"msg":"Pre-read connection validation succeeded"}},{"timestamp":***,"message":{"level":30,"msg":"Syncing ExampleSource"}},{"timestamp":***,"message":{"level":30,"msg":"Finished syncing ExampleSource"}}]}
 "
 `;
 
 exports[`runSrcSync should success with specified output file 1`] = `
 "{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6uuBQBDv6ajAgAAAA=="}},"type":"STATE","redactedConfig":{"user":"chris"},"sourceType":"example","sourceVersion":***}
-{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uji8uSSxJVbKqrq0FAFiOMFAfAAAA"}},"type":"STATE","sourceStatus":{"status":"SUCCESS"}}
-{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uji8uSSxJVbKqrq0FAFiOMFAfAAAA"}},"type":"STATE","logs":[{"timestamp":***,"message":{"level":30,"msg":"Source version: ***"}},{"timestamp":***,"message":{"level":30,"msg":"Config: {\\"user\\":\\"chris\\"}"}},{"timestamp":***,"message":{"level":30,"msg":"Catalog: {}"}},{"timestamp":***,"message":{"level":30,"msg":"State: {}"}},{"timestamp":***,"message":{"level":30,"msg":"Performing pre-read connection validation"}},{"timestamp":***,"message":{"level":30,"msg":"Pre-read connection validation succeeded"}},{"timestamp":***,"message":{"level":30,"msg":"Syncing ExampleSource"}},{"timestamp":***,"message":{"level":30,"msg":"Finished syncing ExampleSource"}}]}
+{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uBgoklqQqWVXX1gIAWI4wUB8AAAA="}},"type":"STATE","sourceStatus":{"status":"SUCCESS"}}
+{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uBgoklqQqWVXX1gIAWI4wUB8AAAA="}},"type":"STATE","logs":[{"timestamp":***,"message":{"level":30,"msg":"Source version: ***"}},{"timestamp":***,"message":{"level":30,"msg":"Config: {\\"user\\":\\"chris\\"}"}},{"timestamp":***,"message":{"level":30,"msg":"Catalog: {}"}},{"timestamp":***,"message":{"level":30,"msg":"State: {}"}},{"timestamp":***,"message":{"level":30,"msg":"Performing pre-read connection validation"}},{"timestamp":***,"message":{"level":30,"msg":"Pre-read connection validation succeeded"}},{"timestamp":***,"message":{"level":30,"msg":"Syncing ExampleSource"}},{"timestamp":***,"message":{"level":30,"msg":"Finished syncing ExampleSource"}}]}
 "
 `;
 
 exports[`runSrcSync should wait for write to complete 1`] = `
 "{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6uuBQBDv6ajAgAAAA=="}},"type":"STATE","redactedConfig":{"user":"chris"},"sourceType":"example","sourceVersion":***}
-{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uji8uSSxJVbKqrq0FAFiOMFAfAAAA"}},"type":"STATE","sourceStatus":{"status":"SUCCESS"}}
-{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uji8uSSxJVbKqrq0FAFiOMFAfAAAA"}},"type":"STATE","logs":[{"timestamp":***,"message":{"level":30,"msg":"Source version: ***"}},{"timestamp":***,"message":{"level":30,"msg":"Config: {\\"user\\":\\"chris\\"}"}},{"timestamp":***,"message":{"level":30,"msg":"Catalog: {}"}},{"timestamp":***,"message":{"level":30,"msg":"State: {}"}},{"timestamp":***,"message":{"level":30,"msg":"Performing pre-read connection validation"}},{"timestamp":***,"message":{"level":30,"msg":"Pre-read connection validation succeeded"}},{"timestamp":***,"message":{"level":30,"msg":"Syncing ExampleSource"}},{"timestamp":***,"message":{"level":30,"msg":"Finished syncing ExampleSource"}}]}
+{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uBgoklqQqWVXX1gIAWI4wUB8AAAA="}},"type":"STATE","sourceStatus":{"status":"SUCCESS"}}
+{"state":{"data":{"format":"base64/gzip","data":"H4sIAAAAAAAAA6tWio8vLilKTcyNTytKLc7ISy0uBgoklqQqWVXX1gIAWI4wUB8AAAA="}},"type":"STATE","logs":[{"timestamp":***,"message":{"level":30,"msg":"Source version: ***"}},{"timestamp":***,"message":{"level":30,"msg":"Config: {\\"user\\":\\"chris\\"}"}},{"timestamp":***,"message":{"level":30,"msg":"Catalog: {}"}},{"timestamp":***,"message":{"level":30,"msg":"State: {}"}},{"timestamp":***,"message":{"level":30,"msg":"Performing pre-read connection validation"}},{"timestamp":***,"message":{"level":30,"msg":"Pre-read connection validation succeeded"}},{"timestamp":***,"message":{"level":30,"msg":"Syncing ExampleSource"}},{"timestamp":***,"message":{"level":30,"msg":"Finished syncing ExampleSource"}}]}
 "
 `;
 

--- a/airbyte-local-cli-nodejs/test/docker.it.test.ts
+++ b/airbyte-local-cli-nodejs/test/docker.it.test.ts
@@ -1,16 +1,20 @@
 import {
+  chmodSync,
   copyFileSync,
   createReadStream,
   createWriteStream,
+  mkdtempSync,
   readFileSync,
   rmSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
+import {tmpdir} from 'node:os';
 import {PassThrough, Writable} from 'node:stream';
 
 import {
   DST_CONFIG_FILENAME,
+  SRC_CONFIG_FILENAME,
   SRC_OUTPUT_DATA_FILE,
   TMP_SPEC_CONFIG_FILENAME,
   TMP_WIZARD_CONFIG_FILENAME,
@@ -33,8 +37,10 @@ const defaultConfig = createTestCfg();
 beforeAll(async () => {
   await pullDockerImage('farosai/airbyte-example-source');
   await pullDockerImage('farosai/airbyte-faros-graphql-source');
+  await pullDockerImage('farosai/airbyte-faros-graphql-source:0.21.57');
   await pullDockerImage('farosai/airbyte-faros-destination');
   await pullDockerImage('airbyte/destination-databricks');
+  await pullDockerImage('airbyte/source-faker');
 }, 120000);
 
 describe('runDiscoverCatalog', () => {
@@ -48,6 +54,44 @@ describe('runDiscoverCatalog', () => {
     const res = await runDiscoverCatalog(`${process.cwd()}/test/resources`, 'farosai/airbyte-faros-graphql-source');
 
     expect(res).toMatchSnapshot();
+  });
+});
+
+describe('runDiscoverCatalog - user mapping', () => {
+  // Simulate the real tmpDir: mode 0700 (mkdtempSync default).
+  // On Linux this means only the owner can access the directory, so the container
+  // must run as the current user (via --user) to read the config file.
+  let testTmpDir: string;
+
+  beforeEach(() => {
+    testTmpDir = mkdtempSync(`${tmpdir()}/`);
+    chmodSync(testTmpDir, 0o700);
+    copyFileSync(
+      `${process.cwd()}/test/resources/${SRC_CONFIG_FILENAME}`,
+      `${testTmpDir}/${SRC_CONFIG_FILENAME}`,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(testTmpDir, {recursive: true, force: true});
+  });
+
+  it('should succeed with 0700 tmpDir using current image (runs as node)', async () => {
+    const res = await runDiscoverCatalog(testTmpDir, 'farosai/airbyte-example-source');
+    expect(res.streams).toBeDefined();
+  });
+
+  it('should succeed with 0700 tmpDir using older image (runs as root)', async () => {
+    const res = await runDiscoverCatalog(testTmpDir, 'farosai/airbyte-faros-graphql-source:0.21.57');
+    expect(res.streams).toBeDefined();
+  });
+
+  it('should succeed with 0700 tmpDir using non-Faros image (runs as airbyte user)', async () => {
+    // airbyte/source-faker runs as the 'airbyte' user — a third distinct UID from both
+    // 'node' (Faros images) and root. Verifies --user mapping works across image types.
+    writeFileSync(`${testTmpDir}/${SRC_CONFIG_FILENAME}`, '{}');
+    const res = await runDiscoverCatalog(testTmpDir, 'airbyte/source-faker');
+    expect(res.streams).toBeDefined();
   });
 });
 

--- a/airbyte-local-cli-nodejs/test/docker.it.test.ts
+++ b/airbyte-local-cli-nodejs/test/docker.it.test.ts
@@ -66,10 +66,7 @@ describe('runDiscoverCatalog - user mapping', () => {
   beforeEach(() => {
     testTmpDir = mkdtempSync(`${tmpdir()}/`);
     chmodSync(testTmpDir, 0o700);
-    copyFileSync(
-      `${process.cwd()}/test/resources/${SRC_CONFIG_FILENAME}`,
-      `${testTmpDir}/${SRC_CONFIG_FILENAME}`,
-    );
+    copyFileSync(`${process.cwd()}/test/resources/${SRC_CONFIG_FILENAME}`, `${testTmpDir}/${SRC_CONFIG_FILENAME}`);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Docusign is encountering issue after we updated our connector images.
The new connector containers run as a node user instead of root and that surfaces that the CLI doesn't properly handle mounted temp directory permissions when different users are running inside and outside of containers, i.e. the cli creates the tmp folder and the container needs to be able to access it.

I was able to reproduce the same issue in cloudshell. And verify adding uid mapping fixes the issue.
Details: add the ssm-user to docker group and verify ssm-user is not having the same uid as the node user (in the container). without adding uid mapping, running airbyte discover would fail and after adding uid mapping, it passes.

checking the user in in our airbyte image
```
❯ docker run -it --rm --entrypoint /bin/sh farosai/airbyte-example-source
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
~/airbyte $ whoami
node
~/airbyte $ id
uid=65532(node) gid=65532(node) groups=65532(node)
```
checking the user in cloudshell
```
ssm-user@ip-10-0-124-13 ~]$ id
uid=1001(ssm-user) gid=1001(ssm-user) groups=1001(ssm-user) context=system_u:system_r:unconfined_service_t:s0
```

Testing
```
[ssm-user@ip-10-0-124-13 ~]$ docker run --rm   -v /tmp/test-configs:/configs:z   farosai/airbyte-example-source   discover --config /configs/faros_airbyte_cli_src_config.json
{"trace":{"type":"ERROR","emitted_at":1779393203285,"error":{"message":"Cannot find module '/configs/faros_airbyte_cli_src_config.json'\nRequire stack:\n- /home/node/airbyte/faros-airbyte-cdk/lib/sources/source-runner.js\n- /home/node/airbyte/faros-airbyte-cdk/lib/index.js\n- /home/node/airbyte/sources/example-source/lib/index.js\n- /home/node/airbyte/sources/example-source/bin/main","stack_trace":"Error: Cannot find module '/configs/faros_airbyte_cli_src_config.json'\nRequire stack:\n- /home/node/airbyte/faros-airbyte-cdk/lib/sources/source-runner.js\n- /home/node/airbyte/faros-airbyte-cdk/lib/index.js\n- /home/node/airbyte/sources/example-source/lib/index.js\n- /home/node/airbyte/sources/example-source/bin/main\n    at Module._resolveFilename (node:internal/modules/cjs/loader:1500:15)\n    at wrapResolveFilename (node:internal/modules/cjs/loader:1071:27)\n    at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1095:10)\n    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1116:12)\n    at Module._load (node:internal/modules/cjs/loader:1285:25)\n    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)\n    at Module.require (node:internal/modules/cjs/loader:1600:12)\n    at require (node:internal/modules/helpers:153:16)\n    at AirbyteSourceRunner.loadConfig (/home/node/airbyte/faros-airbyte-cdk/lib/sources/source-runner.js:224:27)\n    at async Command.<anonymous> (/home/node/airbyte/faros-airbyte-cdk/lib/sources/source-runner.js:85:32)","internal_message":"Error","failure_type":"system_error","code":"MODULE_NOT_FOUND","requireStack":["/home/node/airbyte/faros-airbyte-cdk/lib/sources/source-runner.js","/home/node/airbyte/faros-airbyte-cdk/lib/index.js","/home/node/airbyte/sources/example-source/lib/index.js","/home/node/airbyte/sources/example-source/bin/main"]}},"type":"TRACE"}
[ssm-user@ip-10-0-124-13 ~]$ docker run --rm   --user $(id -u):$(id -g)   -v /tmp/test-configs:/configs:z   farosai/airbyte-example-source  discover --config /configs/faros_airbyte_cli_src_config.json
{"catalog":{"streams":[{"name":"builds","json_schema":{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"uid":{"type":"string"},"source":{"type":"string"},"updated_at":{"type":"integer"},"fields":{"type":"object","properties":{"command":{"type":"string"},"number":{"type":"integer"}}},"more_fields":{"type":["null","array"],"items":{"type":"object","properties":{"name":{"type":"string"},"value":{"type":["string","integer"]},"nested":{"type":"object","properties":{"value":{"type":"string"}}}}}},"__faros_data":{"type":["object","null"],"additionalProperties":true}}},"supported_sync_modes":["full_refresh","incremental"],"source_defined_cursor":true,"default_cursor_field":["updated_at"],"source_defined_primary_key":[["uid"],["source"]]}]},"type":"CATALOG"}
```

--

This pull request updates the Airbyte local CLI Node.js package to version 0.2.2 and introduces improvements for running Docker containers with correct user permissions on Unix systems. It also updates integration test snapshots to reflect new and updated configuration options and output changes.

**Docker container execution improvements:**

* Added a `getContainerUser` function in `docker.ts` to ensure containers run as the current user on Unix, preserving permissions on bind-mounted directories. This function is now used in all relevant Docker run invocations. [[1]](diffhunk://#diff-1568971b57c16b9510c3f5b68e27f58526f2a2dbebd9368ed889095340c5b2e1R45-R54) [[2]](diffhunk://#diff-1568971b57c16b9510c3f5b68e27f58526f2a2dbebd9368ed889095340c5b2e1R318) [[3]](diffhunk://#diff-1568971b57c16b9510c3f5b68e27f58526f2a2dbebd9368ed889095340c5b2e1R379) [[4]](diffhunk://#diff-1568971b57c16b9510c3f5b68e27f58526f2a2dbebd9368ed889095340c5b2e1R463) [[5]](diffhunk://#diff-1568971b57c16b9510c3f5b68e27f58526f2a2dbebd9368ed889095340c5b2e1R593) [[6]](diffhunk://#diff-1568971b57c16b9510c3f5b68e27f58526f2a2dbebd9368ed889095340c5b2e1R756)

**Version bump:**

* Updated the package version to `0.2.2` in `package.json`, `package-lock.json`, and `version.ts`. [[1]](diffhunk://#diff-dd1fdd4ed8d30e34f5430be5f8169d15bcf36c6b45f4ca89a2e3f645a148add9L3-R3) [[2]](diffhunk://#diff-eda83e8c4f8f7ba146ee529af4db344b8e640cd31ffab00b37fa3e1a1e57ce95L3-R9) [[3]](diffhunk://#diff-2e15914795a909ef072612be1c377af1e5a2f61a530489ca0a5a0cc5df329d1fL1-R1)

**Integration test updates:**

* Updated test snapshots in `docker.it.test.ts.snap` to include new configuration options (`describe_connection`, `origins_filter`, `probe_streams`) and to reflect changes in the order and output of configuration fields. [[1]](diffhunk://#diff-8cf1c35d5b32575021ff52f6c748f0e1f815e58cbdbbc323c1160d391efed2e1R326-R332) [[2]](diffhunk://#diff-8cf1c35d5b32575021ff52f6c748f0e1f815e58cbdbbc323c1160d391efed2e1R355-R377) [[3]](diffhunk://#diff-8cf1c35d5b32575021ff52f6c748f0e1f815e58cbdbbc323c1160d391efed2e1L380-R403)
* Adjusted expected sync output in test snapshots to match changes in the output, likely due to the Docker user handling or related logic.